### PR TITLE
Set Date Header

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -204,6 +204,13 @@ EmailMessage.prototype.generateHeaders = function(){
         ].join(": "));
     }
     
+    // Date
+    var date = new Date;
+    headers.push([
+        upperFirst("Date"),
+        date.toGMTString()
+    ].join(": "));
+
     // From
     var from = this.generateAddresses(this.sender,1, "fromAddress");
     if(from.length){


### PR DESCRIPTION
Some email Clients don't set email date if Date header not available.
Others use smtp date..
This path use toGMTString to make date string.
