### PR TITLE
Boundary token issue corrected for HTML emails sent to Yahoo! Web Mail users.

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -173,7 +173,7 @@ EmailMessage.prototype.prepareVariables = function(){
             }
         }
         this.content_type = "multipart/"+(this.content_mixed?mixed:"alternative")+
-                "; boundary="+this.content_boundary;
+                "; boundary=\""+this.content_boundary+"\"";
     }else{
         this.content_multipart = false;
         this.content_type = "text/plain; charset="+this.charset;
@@ -310,7 +310,7 @@ EmailMessage.prototype.generateBody = function(){
 
     if(this.content_mixed){
         rows.push("--"+this.content_boundary);
-        rows.push("Content-Type: multipart/alternative; boundary="+body_boundary);
+        rows.push("Content-Type: multipart/alternative; boundary=\""+body_boundary+"\"");
         rows.push("");
     }
     


### PR DESCRIPTION
Some web email clients including "Yahoo! Web Mail" do not display emails with header "Content-Type: multipart/alternative", if boundary token is not enclosed by quotes. As a result, HTML emails sent using Nodemailer will not be displayed on "Yahoo! Web Mail", if following change will not be applied.
