### PR TITLE
Patch for #34

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -186,9 +186,10 @@ var gencounter = 0,
  *  NB! mail.SMTP needs to be set before sending any e-mails!
  **/
 function EmailMessage(params, profile){
+    profile = profile || 'default';
     EventEmitter.call(this);
     params = params || {};
-    this.SERVER = params.server || exports.PROFILES[profile] || exports.PROFILES.default || exports.SMTP;
+    this.SERVER = params.server || exports.PROFILES[profile] || exports.SMTP;
     this.sender = params.sender;
     this.headers = params.headers || {};
     this.to = params.to;


### PR DESCRIPTION
This patch works a bit differently than discussed in #34. Basically, the multi-config profiles are mostly independent from the SMTP configuration object, so code that uses the SMTP object is unaffected.

The new `mail.PROFILES` object by default has getter/setter function that link the `SMTP` object with `default` key. The default profile is used as  a fallback profile. EmailMessage fall backs on `SMTP` object as last resort, though, if the user destroyed the `default` getter/setter by assigning an Object literal to PROFILES object. (It's documented in the comments.)

`send_mail` and `EmailMessage` now take an optional `profile` parameter that can be used to switch profiles.
