### PR TITLE
`generateBody()` dosen't encode quoted-printable, if encoding is not quoted-printable

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -275,7 +275,11 @@ EmailMessage.prototype.generateHeaders = function(){
 EmailMessage.prototype.generateBody = function(){
 
     if(!this.content_multipart){
-        return this.body && mimelib.encodeQuotedPrintable(this.body) || "";
+        if(this.encoding == "quoted-printable"){
+            return this.body && mimelib.encodeQuotedPrintable(this.body) || "";
+        }else{
+            return this.body;
+        }
     }
     
     var body_boundary = this.content_mixed?


### PR DESCRIPTION
I wont to use japanese encoding ISO-2022-JP. But body is encoded to quoted-printable. If encoding is not quoted-printable, I don't want to encode. 
