### PR TITLE
fixes 421 response handling (smtp is not defined)

### DIFF
--- a/lib/engines/SMTP.js
+++ b/lib/engines/SMTP.js
@@ -657,6 +657,7 @@ SMTPClient.prototype._starttlsHandler = function(callback){
  * login function on success.
  **/
 SMTPClient.prototype._handshake = function(callback){
+    var smtp = this;
     
     this.emit("connect");
     this._sendCommand("EHLO "+this.hostname, (function(error, data){


### PR DESCRIPTION
The smtp.close() statement on line 666 of SMTP.js was invalid, this fixes it. This fix doesn't affect the API in any way (unless some crazy person was relying on the exception!).
