### PR TITLE
Allow disabling of TLS

### DIFF
--- a/lib/engines/SMTP.js
+++ b/lib/engines/SMTP.js
@@ -59,6 +59,7 @@ exports.send = function(emailMessage, config, callback) {
             user: emailMessage.SERVER.user,
             pass: emailMessage.SERVER.pass,
             ssl: emailMessage.SERVER.ssl,
+            tls: emailMessage.SERVER.tls,
             debug: emailMessage.debug,
             instanceId: config.instanceId
     });
@@ -97,6 +98,7 @@ exports.SMTPClient = SMTPClient;
  *   defaults to OS hostname or "localhost"
  * - use_authentication (Boolean): is authorization needed, default is false
  * - ssl (Boolean): use SSL (port 465)
+ * - tls (Boolean): allow TLS (port 465)
  * - user (String): the username if authorization is needed
  * - pass (String): the password if authorization is needed
  * 
@@ -709,14 +711,17 @@ SMTPClient.prototype._handshake = function(callback){
             this.remote_auth_cram_sha1 = true;
         }
 
+        var shouldSupportTLS = this.options.tls !== false;
         // check for TLS support
-        if(data.match(/STARTTLS/i)){
+        if(shouldSupportTLS && data.match(/STARTTLS/i)){
             if(!this.remote_starttls) {
                 this.remote_starttls = true;
                 // start tls and rerun HELO
                 this._starttlsHandler(this._handshake.bind(this,callback));
                 return;
             }
+        } else {
+            this.remote_starttls = false;
         }
 
         this.emit("connection_stable");


### PR DESCRIPTION
My company uses authsmtp.com's smtp service; they allow TLS/SSL, but you have to enable it for your account and if you do it slows things down and each email costs as though you sent 2. For those reasons, we didn't want to use TLS.

This patch makes it so you can pass tls: false in your nodemailer.SMTP config object and it will not call STARTTLS.

There may be a better way to do this; I'm not sure. I also considered making tls: true force TLS to be used with any other value (null, undefined, "frank", etc) meaning use the default, but I dont' know the codebase well enough to do that easily.  If you want to make something more elegant I'll switch to using your solution, but it'd be nice to have a solution in the main codebase so I don't have to maintain my own fork =]
