### PR TITLE
Clear the timeout on connection close.

### DIFF
--- a/lib/engines/SMTP.js
+++ b/lib/engines/SMTP.js
@@ -362,6 +362,7 @@ SMTPClient.prototype.send = function(data, callback){
  * the e-mail is sent (with QUIT) but might be server specific.
  **/
 SMTPClient.prototype.close = function(){
+    clearTimeout(this._timeoutTimer);
     this._connected && this._connection && this._connection.end();
     this._connected = false;
 };


### PR DESCRIPTION
When using SMTP, a timeout was being set for the initial connection. If the connection had an error event, such as a connection refusal, the callback got called, but the timeout was never cleared. This caused the callback to be called a second time. The only times the timeout was being cleared were in the _onData method and when setting a new timeout.

I have added a clearTimeout to the close method, which gets called on a connection error, among other places.
