### PR TITLE
Proposed changes to send callback

### DIFF
--- a/examples/example_ses.js
+++ b/examples/example_ses.js
@@ -35,17 +35,14 @@ var message = {
 };
 
 // Callback to be run after the sending is completed
-var callback = function(error, success){
+var callback = function(error){
     if(error){
         console.log('Error occured');
         console.log(error.message);
         return;
     }
-    if(success){
-        console.log('Message sent successfully!');
-    }else{
-        console.log('Message failed, reschedule!');
-    }
+
+  console.log('Message sent successfully!');
 };
 
 console.log('Sending Mail');

--- a/examples/example_smtp.js
+++ b/examples/example_smtp.js
@@ -40,17 +40,14 @@ var message = {
 };
 
 // Callback to be run after the sending is completed
-var callback = function(error, success){
+var callback = function(error){
     if(error){
         console.log('Error occured');
         console.log(error.message);
         return;
     }
-    if(success){
-        console.log('Message sent successfully!');
-    }else{
-        console.log('Message failed, reschedule!');
-    }
+
+  console.log('Message sent successfully!');
 };
 
 console.log('Sending Mail');

--- a/lib/engines/SES.js
+++ b/lib/engines/SES.js
@@ -57,14 +57,14 @@ function buildResponseHandler(callback) {
         
         //Performs error handling and executes callback, if it exists
         response.on('end', function(err) {
-            if(err instanceof Error) {
-                return callback && callback(err, null);
-            }
-            if(response.statusCode != 200) {
-                return callback &&
-                    callback(new Error('Email failed: ' + response.statusCode + '\n' + body), null);
-            }
-            return callback && callback(null, body);
+        
+            if(err instanceof Error)
+              return callback && callback(err);
+            
+            if(response.statusCode != 200)
+              return callback &&
+                    callback(new Error('Email failed: ' + response.statusCode + '\n' + body));
+           
         });
     };
 }

--- a/lib/engines/SMTP.js
+++ b/lib/engines/SMTP.js
@@ -290,19 +290,17 @@ SMTPClient.prototype._flushMessages = function() {
             smtp.send(headers+"\r\n\r\n");
             smtp.send(body);
         }
+
         smtp.send("\r\n.", function(error, message){
-            if(!error){
-                smtp.sending = false;
-                smtp._flushMessages();
-                process.nextTick(function(){
-                    callback && callback(null, true);
-                });
-            }else{
-                smtp.close();
-                process.nextTick(function(){
-                    callback && callback(null, false);
-                });
-            }
+
+          if (error) {
+            smtp.close();
+            smtp.emit('error', new Error(error));
+            return;
+          }
+
+          smtp.sending = false;
+          smtp._flushMessaeges();
         });
     }
 };

--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -19,11 +19,8 @@ exports.send = function(emailMessage, config, callback) {
     var path = typeof config=="string"?config:"sendmail";
     exec('echo "'+(headers+"\r\n\r\n"+body).replace(/"/g,'\\"')+'" | '+path+" -t", function(error){
         process.nextTick(function(){
-            if(error){
-                callback && callback(error, null);
-            }else{
-                callback && callback(null, true);
-            }
+          if(error)
+            callback && callback(error);
         });
     });
     return;


### PR DESCRIPTION
Hi,

I've been using node mailer for sometime now and feel the callback can be simplified a bit. Instead of returning a status if email was sent successfully, how about changing it to be called only when there's an error. So success is more of an implied action.

This way if an error occurs a dev can get more detailed info on why an email wasn't sent and act on it. Another idea is to create a true status object that looks like this. { status: true/false, response: 'response from MTA' }

Let me know what you think.

-Ardie
