### PR TITLE
Add support for AUTH LOGIN in SMTP transport configuration

### DIFF
--- a/lib/engines/smtp.js
+++ b/lib/engines/smtp.js
@@ -19,6 +19,7 @@ module.exports = SMTPTransport;
  *     <li><b>port</b> - port of the SMTP server</li>
  *     <li><b>secureConnection</b> - use SSL</li>
  *     <li><b>name</b> - the name of the client server</li>
+ *     <li><b>authMethod</b> -specified the authMethod, value can be ["plain", "login"], default is "plain"</li>
  *     <li><b>auth</b> - authentication object as <code>{user:"...", pass:"..."}</code>
  *     <li><b>ignoreTLS</b> - ignore server support for STARTTLS</li>
  *     <li><b>debug</b> - output client and server messages to console</li>
@@ -53,6 +54,7 @@ SMTPTransport.prototype.initOptions = function(){
         if(!this.options.auth){
             this.options.auth = {};
         }
+        this.options.authMethod = this.options.authMethod || "PLAIN";
         this.options.auth.user = this.options.auth.user || this.options.user;
         this.options.auth.pass = this.options.auth.pass || this.options.pass;
         this.options.auth.XOAuthToken = this.options.auth.XOAuthToken || this.options.XOAuthToken;


### PR DESCRIPTION
Hi, 

I've add the configuration support for authMethod, which can specified the SMTP client authentication method  is plain or login. the default value is plain. 
