### PR TITLE
Updated .stripHTML() and test to strip style from html

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,8 +21,8 @@ module.exports.stripHTML = stripHTML;
 function stripHTML(str){
     str = (str || "").toString("utf-8").trim();
 
-    // remove style
-    str = str.replace(/<style[\s\S]{1,}?\/style>/gi, '');
+    // remove head
+    str = str.replace(/<head[\s\S]{1,}?\/head>/gi, '');
 
     // replace newlines
     str = str.replace(/\r?\n|\r/g,"-\u0002\u0002-");

--- a/test/nodemailer.js
+++ b/test/nodemailer.js
@@ -12,7 +12,7 @@ exports["General tests"] = {
     
     "stripHTML": function(test){
         
-        var html = "<style>h1{color:#fe57a1}</style><h1>Tere &raquo;</h1><ul><li>Test</li></ul>",
+        var html = "<html><head><title>Title</title><style>h1{color:#fe57a1}</style></head><body><h1>Tere &raquo;</h1><ul><li>Test</li></ul></body></html>",
             output = "Tere »\n======\n\n  * Test";
         
         test.equal(stripHTML(html).trim(), output);


### PR DESCRIPTION
Added a regexp to remove all style tags and anything inbetween when using the .stripHTML() method. I've also updated the stripHTML test to prove that it works.
