### PR TITLE
Use envelope options for sendmail transport

### DIFF
--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -34,10 +34,8 @@ function SendmailTransport(config){
  */
 SendmailTransport.prototype.sendMail = function(emailMessage, callback) {
 
-    // sendmail strips this header line by itself
-    emailMessage.options.keepBcc = true;
-    
-    var sendmail = spawn(this.path, ["-t"].concat(this.args));
+    var envelope = emailMessage.getEnvelope();
+    var sendmail = spawn(this.path, ["-f"].concat(envelope.from).concat(envelope.to));
     
     sendmail.on('exit', function (code) {
         var msg = "Sendmail exited with "+code;


### PR DESCRIPTION
Previously, the envelope information was unused. Sendmail would
construct the envelope itself from the message headers.
