### PR TITLE
Fix stripHTML to properly format Markdown links

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,3 @@
-
 // expose to the world
 module.exports.stripHTML = stripHTML;
 
@@ -102,7 +101,7 @@ function stripHTML(str){
         var paramMatch = params.match(/href\s*=\s*['"]([^'"]+)['"]/),
             url = paramMatch && paramMatch[1] || "#";
 
-        return "(" + content.trim() + ")" + "[" + url +"]";
+        return "[" + content.trim() + "]" + "(" + url +")";
     });
 
     // UL, replace with newlines


### PR DESCRIPTION
stripHTML returned

```
(label)[url]
```

but Markdown links should be of the form

```
[label](url)
```

The attached commit fixes this.
