### PR TITLE
Use custom Date header value if specified in options

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -262,7 +262,11 @@ Nodemailer.prototype.setModuleHeaders = function(){
     this.mailcomposer.addHeader("X-Mailer", this.generateUserAgentString());
     
     // Date
-    this.mailcomposer.addHeader("Date", new Date().toUTCString());
+    if(this.options.date){
+        this.mailcomposer.addHeader("Date", this.options.date)
+    }else{
+        this.mailcomposer.addHeader("Date", new Date().toUTCString());
+    }
     
     // Message ID
     if(this.options.messageId){

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nodemailer",
     "description": "Easy to use module to send e-mails, supports unicode and SSL/TLS",
-    "version": "0.3.30",
+    "version": "0.3.31",
     "author" : "Andris Reinman",
     "maintainers":[
         {

--- a/test/nodemailer.js
+++ b/test/nodemailer.js
@@ -76,6 +76,21 @@ exports["General tests"] = {
             test.done();
         })
     },
+
+    "Use custom Date value": function(test){
+        var transport = nodemailer.createTransport("Stub"),
+            mailOptions = {
+                date: "Fri, 5 Nov 2012 09:41:00 -0800"
+            };
+
+        transport.sendMail(mailOptions, function(error, response){
+            test.ifError(error);
+            test.ok(response.message.match(/Date:\s*Fri, 5 Nov 2012 09:41:00 -0800/));
+            // default not present
+            test.ok(!response.message.match(/^Date:\s*[0-9\s:a-yA-Y]+\s+GMT$/m));
+            test.done();
+        })
+    },
     
     "Use In-Reply-To": function(test){
         var transport = nodemailer.createTransport("Stub"),


### PR DESCRIPTION
Setting a custom Date header (in the same way the Message-Id can be customized) gives us the ability to set different UTC offsets when sending mail on behalf of users in different timezones. It also lets us workaround an issue seen in at least one version of iOS Apple Mail where the standard GMT datetime is interpreted in conflicting ways.
