### PR TITLE
Pass http response object to the SES sendMail callback

### DIFF
--- a/lib/engines/ses.js
+++ b/lib/engines/ses.js
@@ -124,10 +124,14 @@ SESTransport.prototype.responseHandler = function(callback, response) {
         }
         if(response.statusCode != 200) {
             return typeof callback == "function" &&
-                callback(new Error('Email failed: ' + response.statusCode + '\n' + body), null);
+                callback(new Error('Email failed: ' + response.statusCode + '\n' + body), {
+                    message: body,
+                    response: response
+                });
         }
         return typeof callback == "function" && callback(null, {
-            message: body
+            message: body,
+            response: response
         });
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nodemailer",
     "description": "Easy to use module to send e-mails, supports unicode and SSL/TLS",
-    "version": "0.3.35",
+    "version": "0.3.36",
     "author" : "Andris Reinman",
     "maintainers":[
         {


### PR DESCRIPTION
Hi Andris,

I am working on an application that uses nodemailer with AWS SES.  I would like to be able to inspect and handle the responses from Amazon in the sendMail callback regardless of the status code without parsing error.message.  This change would accomplish that and also enable logging the responses from Amazon without modifying engines/ses.js.
Let me know if there is anything I can do to get this pulled.

Thanks for all the work you have put into this great library,
-Joe
