### PR TITLE
Fix to #129 breaks sample code (and my code)

### DIFF
--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -35,7 +35,7 @@ function SendmailTransport(config){
 SendmailTransport.prototype.sendMail = function(emailMessage, callback) {
 
     var envelope = emailMessage.getEnvelope();
-    var sendmail = spawn(this.path, this.args || ["-f"].concat(envelope.from).concat(envelope.to));
+    var sendmail = spawn(this.path, this.args.concat(["-f"]).concat(envelope.from).concat(envelope.to));
     sendmail.on('exit', function (code) {
         var msg = "Sendmail exited with "+code;
         if(typeof callback == "function"){


### PR DESCRIPTION
commit 40524e127c85cb45887fac0fcb9426c7f4128198 breaks sample code (examples/example_sendmail.js).

I noticed that `this.args` is `[]` in lib/engines/sendmail.js if it is not specified otherwise. Yet, `[]||whatever` always evaluates to `[]`. 

Without `["-f"].concat(envelope.from).concat(envelope.to))` being inserted, the `sendmail` exits with error code 75 all the same.

I tried invoking `sendmail` directly through shell without any argument and feed its stdin with exactly the same input nodemailer would. Here's the error message: 

> sendmail: fatal: Recipient addresses must be specified on the command line or via the -t option

Further, I observed that without `envelope.to`, sendmail always fail. Without `-f envolope.from`, sendmail will run and email will be delivered. However, there is a slight behavior difference. Without `-f envelope.from`, `sender` (not `from`, they are different) will be the system user (user-name@host-name). With `-f envelope.from`, `sender` will be the same as `from`. Therefore, none of these should be omitted even if `args` is specified by the user.
