### PR TITLE
minor improvement to submit alternatives without array

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -298,11 +298,14 @@ Nodemailer.prototype.setAlternatives = function(){
     if(!Array.isArray(this.options.alternatives)){
         this.mailcomposer.addAlternative(this.options.alternatives);
     }
-    var alternative;
-    for(var i=0, len=this.options.alternatives.length; i<len; i++){
-        alternative = this.options.alternatives[i];
-        this.mailcomposer.addAlternative(alternative);
+    else {
+        var alternative;
+        for(var i=0, len=this.options.alternatives.length; i<len; i++){
+            alternative = this.options.alternatives[i];
+            this.mailcomposer.addAlternative(alternative);
+        }
     }
+    
 };
 
 /**


### PR DESCRIPTION
Instead of 
var options = {
sender: 'Sender sender@example.com',
to: '"Receiver" receiver@example.com',
subject: 'Appointment',
text: 'Appointment Plain',
html: 'Appointment HTML',
alternative : [
{
contentType: "text/calendar; method=REQUEST; name="meeting.ics"",
contents: new Buffer(...),
contentEncoding: 7bit
}
]
};

you could also write:

var options = {
sender: 'Sender sender@example.com',
to: '"Receiver" receiver@example.com',
subject: 'Appointment',
text: 'Appointment Plain',
html: 'Appointment HTML',
alternative : 
{
contentType: "text/calendar; method=REQUEST; name="meeting.ics"",
contents: new Buffer(...),
contentEncoding: 7bit
}
};
