### PR TITLE
Bug fixed for the zoho login options

### DIFF
--- a/lib/wellknown.js
+++ b/lib/wellknown.js
@@ -38,7 +38,8 @@ module.exports = {
         host: "smtp.zoho.com",
         secureConnection: true,
         port: 465,
-        requiresAuth: true
+        requiresAuth: true,
+        authMethod: 'LOGIN'
     },
     "iCloud":{
         host:"smtp.mail.me.com",


### PR DESCRIPTION
Zoho do not support PLAIN login method, so the default authMethod should be 'LOGIN'. This is used in module simplesmtp.
