### PR TITLE
Add forgotten Mailjet in ReadMe SMTP services list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Currently supported services are:
   * **mail.ee**
   * **Mail.Ru**
   * **Mailgun**
+  * **Mailjet**
   * **Mandrill**
   * **Postmark**
   * **QQ**


### PR DESCRIPTION
Mailjet is already supported (see wellknown.js) but it is not indicated in the ReadMe SMTP services list.
