### PR TITLE
Add a new smtp service form Godaddy email

### DIFF
--- a/lib/wellknown.js
+++ b/lib/wellknown.js
@@ -126,5 +126,17 @@ module.exports = {
         host: "smtpout.secureserver.net",
         port: 25,
         requiresAuth: true
+    },
+    "GodaddyEurope": {
+        transport: "SMTP",
+        host: "smtp.europe.secureserver.net",
+        port: 25,
+        requiresAuth: true
+    },
+    "GodaddyAsia": {
+        transport: "SMTP",
+        host: "smtp.asia.secureserver.net",
+        port: 25,
+        requiresAuth: true
     }
 };


### PR DESCRIPTION
Many people use the Godaddy email service for free like me.
I think that the Nodemailer can send an email by Godaddy, so I add a new configure for Godaddy in wellknown.js.
Hope you can merge it.

Thanks for your work.
