### PR TITLE
Fixing Amazon SES, fatal error caused by bad connection

### DIFF
--- a/lib/engines/ses.js
+++ b/lib/engines/ses.js
@@ -103,7 +103,26 @@ SESTransport.prototype.handleMessage = function(email, callback) {
         request = http.request(reqObj, this.responseHandler.bind(this, callback));
     }
     request.end(params);
+
+    // Handle fatal errors
+    request.on("error", this.errorHandler.bind(this, callback) );
 };
+
+
+
+/**
+ * <p>Handles a fatal error response for the HTTP request to SES</p>
+ *
+ * @param {Function} callback Callback function to run on end (binded)
+ * @param {Object} response HTTP Response object
+ */
+SESTransport.prototype.errorHandler = function(callback, err) {
+    if( ! ( err instanceof Error) ) {
+        err = new Error('Email failed ' + ("statusCode" in err ? err.statusCode : null ), {response:err});
+    }
+    return typeof callback == "function" && callback(err, null);
+};
+
 
 /**
  * <p>Handles the response for the HTTP request to SES</p>


### PR DESCRIPTION
Hi Andris, I found a breaking bug and have a fix for it.

Bad connections cause a Fatal Error. And an uncaught error is thrown.

```
$ node test.js

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: getaddrinfo ENOTFOUND
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:124:16)
```

Its actually a problem with `http.request()` made without a `req.on('error', handler)`. You can demo this by turning your internet connection off and running this code below (toggle the comment to see the fix).

```
// TURN OFF YOUR INTERNET CONNECTION TO TEST
var https = require('https');
try{

    var req = https.request("https://google.com", function(){
        console.log(arguments); 
    })
    // UNCOMMENT THIS NEXT LINE TO FIX
    // req.on('error', function(e) { console.log('problem with request: ' + e.message); });
}
catch(e){
    console.log("Doesn't get caught");
}
```

Please merge my changes below. :)

Great project, thankyou.
