### PR TITLE
sendmail transport: better exception handling, wait for sendmail complet...

### DIFF
--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -51,25 +51,74 @@ function SendmailTransport(config){
  * @param {Object} emailMessage MailComposer object
  * @param {Function} callback Callback function to run when the sending is completed
  */
-SendmailTransport.prototype.sendMail = function(emailMessage, callback) {
+SendmailTransport.prototype.sendMail = function sendMail(emailMessage, callback) {
 
     var envelope = emailMessage.getEnvelope(),
         args = this.args || ["-f"].concat(envelope.from).concat(envelope.to),
         sendmail,
+        err,
+        cbCounter = 2,
+        didCb,
+        marker = 'SendmailTransport.sendMail',
         transform;
-    
+
     args.unshift("-i"); // force -i to keep single dots
 
-    sendmail = spawn(this.path, args);
+    try {
+        sendmail = spawn(this.path, args);
+    } catch (e) {
+        e[marker] = 'spawn exception';
+        sendmailResult(e);
+    }
 
-    sendmail.on('exit', function (code) {
-        var msg = "Sendmail exited with "+code;
-        if(typeof callback == "function"){
-            callback(code?new Error(msg):null, {message: msg, messageId: emailMessage._messageId});
+    if (sendmail) {
+        sendmail.on('error', sendmailError);
+        sendmail.once('exit', sendmailExit);
+        sendmail.once('close', endEvent);
+        sendmail.stdin.on('error', sendmailStdinError);
+
+        transform = new NewlineTransform();
+        emailMessage.pipe(transform).pipe(sendmail.stdin);
+        emailMessage.streamMessage();
+    }
+
+    function sendmailError(e) {
+        e[marker] = 'sendmailError'
+        sendmailResult(e)
+    }
+
+    function sendmailStdinError(e) {
+        e[marker] = 'sendmailStdinError'
+        sendmailResult(e)
+    }
+
+    function sendmailExit(code) {
+        var err
+
+        if (!code) endEvent()
+        else sendmailResult(new Error("Sendmail exited with " + code))
+    }
+
+    function endEvent() {
+        if (!--cbCounter) sendmailResult()
+    }
+
+    function sendmailResult(e) {
+        if (!didCb) {
+            didCb = true;
+            if (typeof callback === 'function') {
+                callback(e)
+                e = null
+            }
         }
-    });
-
-    transform = new NewlineTransform();
-    emailMessage.pipe(transform).pipe(sendmail.stdin);
-    emailMessage.streamMessage();
+        if (e) {
+            /*
+            The nodemailer module needs an events.EventEmitter so that additional errors can be emitted.
+            As of 12/16/2013 it does not have that, so throw spurious errors here
+            There should not be any, but the Titanic was unsinkable.
+            */
+            e.extra = true
+            throw e;
+        }
+    }
 };


### PR DESCRIPTION
Improvements to nodemailer 0.5.15:

sendmail transport:
- Capture possible exceptions thrown by child_process.spawn.
- Capture possible exceptions when writing to the sendmail process' stdin.
- Wait to fire callback until the sendmail process has both exited successfully and closed its stdio.
- Listen for errors emitted by the sendmail process

As things were before:
- SendmailTransport.prototype.sendMail could throw exception despite having a callback.
- EPIPE exceptions was thrown after nodemailer had been successfully closed.
- ENOENT exceptions for a sendmail executable not found was thrown after nodemailer had been successfully closed.
