### PR TITLE
High-res build-passing and NPM module badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Nodemailer is Windows friendly, you can install it with *npm* on Windows just li
 
 **[Read about using Nodemailer from the Node Knockout blog](http://blog.nodeknockout.com/post/34641712180/sending-email-from-node-js)**
 
-[![Build Status](https://secure.travis-ci.org/andris9/Nodemailer.png)](http://travis-ci.org/andris9/Nodemailer)
-[![NPM version](https://badge.fury.io/js/nodemailer.png)](http://badge.fury.io/js/nodemailer)
+[![Build Status](https://secure.travis-ci.org/andris9/Nodemailer.svg)](http://travis-ci.org/andris9/Nodemailer)
+<a href="http://badge.fury.io/js/nodemailer"><img src="https://badge.fury.io/js/nodemailer@2x.png" alt="NPM version" height="18"></a>
 
 ## Notes and information
 


### PR DESCRIPTION
For **NPM module** badge the font on https://badge.fury.io/js/nodemailer.svg looks weird, so I used HTML retina version instead.
