### PR TITLE
Add AOL to well-known services

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ to enter the hostname or port number, just use the `service` parameter
 
 Currently supported services are:
 
+  * **AOL**
   * **DynectEmail**
   * **Gmail**
   * **hot.ee**

--- a/lib/wellknown.js
+++ b/lib/wellknown.js
@@ -165,5 +165,13 @@ module.exports = {
         host: "smtpcloud.sohu.com",
         port: 25,
         requiresAuth: true
+    },
+    // http://help.aol.com/help/microsites/microsite.do?cmd=displayKC&externalId=73332
+    "AOL":{
+        transport: "SMTP",
+        host: "smtp.aol.com",
+        port: 587,
+        requiresAuth: true,
+        domains: ["aol.com"]
     }
 };


### PR DESCRIPTION
Adding support for AOL to wellknown.js per the instructions at http://help.aol.com/help/microsites/microsite.do?cmd=displayKC&externalId=73332.
