### PR TITLE
Fix adding many "-i" parameters

### DIFF
--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -54,17 +54,17 @@ function SendmailTransport(config){
 SendmailTransport.prototype.sendMail = function sendMail(emailMessage, callback){
 
     var envelope = emailMessage.getEnvelope(),
-        args = this.args || ["-f"].concat(envelope.from).concat(envelope.to),
+        args2 = this.args || ["-f"].concat(envelope.from).concat(envelope.to),
         sendmail,
         cbCounter = 2,
         didCb,
         marker = "SendmailTransport.sendMail",
         transform;
 
-    args.unshift("-i"); // force -i to keep single dots
+    args2.unshift("-i"); // force -i to keep single dots
 
     try {
-        sendmail = spawn(this.path, args);
+        sendmail = spawn(this.path, args2);
     } catch (e){
         e[marker] = "spawn exception";
         sendmailResult(e);


### PR DESCRIPTION
in function sendMail, args is the same as this.args, so we continue adding "-i" to the command line for each mail sent.

Make a private variable args2 (maybe we need a better name) and use it instead to avoid this.
