### PR TITLE
bugfix (adding "-i" to sendmail command line for each new mail)  by copying this.args instead of just making a reference

### DIFF
--- a/lib/engines/sendmail.js
+++ b/lib/engines/sendmail.js
@@ -54,7 +54,7 @@ function SendmailTransport(config){
 SendmailTransport.prototype.sendMail = function sendMail(emailMessage, callback){
 
     var envelope = emailMessage.getEnvelope(),
-        args = this.args || ["-f"].concat(envelope.from).concat(envelope.to),
+        args = this.args ? this.args.slice() : ["-f"].concat(envelope.from).concat(envelope.to),
         sendmail,
         cbCounter = 2,
         didCb,


### PR DESCRIPTION
If we have args configured when creating a transport, we need to copy this.args instead of just making a reference because we get one extra "-i" parameters for every mail sent because of args.unshift("-i"), like this (from my exim log):

464 args: sendmail -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i -i ....

We could probably make it more efficient by initializing "-i" in constructor for this.args and in the default args initializer ( ["-f"].concat(envelope.from).concat(envelope.to) ), but I just wanted to provide a bugfix first.
