### PR TITLE
Allow clients to set a custom identityString

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -89,6 +89,10 @@ function Nodemailer(options){
 
     mailcomposerOptions.identityString = X_MAILER_NAME + " " + packageData.version;
 
+    if(this.options.identityString){
+        mailcomposerOptions.identityString = this.options.identityString;
+    }
+
     if(this.options.encoding){
         mailcomposerOptions.encoding = this.options.encoding;
     }


### PR DESCRIPTION
Instead of showing `Nodemailer-<version>` throughout the email source, I would like to show a different identity string - this allows users to do just that.
