### PR TITLE
New SES option with aws-sdk module

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ transport.sendMail({
 `type` parameter can be one of the following:
 
   * **SMTP** for using SMTP
-  * **SES** for using Amazon SES
+  * **SES** for using Amazon SES with AWS Identity and Access Management (IAM) roles
   * **Sendmail** for utilizing systems *sendmail* command
   * **Pickup** for storing the e-mail in a directory on your machine
   * **Direct** for sending e-mails directly to recipients MTA servers
@@ -325,15 +325,25 @@ var transportOptions = {
 
 ### Setting up SES
 
-SES is actually a HTTP based protocol, the compiled e-mail and related info
-(signatures and such) are sent as a HTTP request to SES servers.
+SES use the aws-sdk node module that wraps all the HTTP requests to SES servers.
+If running on an Amazon EC2 instance, it allows the use of IAM Roles instead of AWS credentials.
+If necessary, the AWS credentials can still be provided to the *createTransport* method or through environment variables ( AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY ).
 
-Possible SES options are the following:
+The SES options were renamed in v0.7. The new names are compatible with the naming convention of the AWS SDK for javascript in nodeJS used in Nodemailer. Thus you can pass a configuration object compatible with the AWS SDK to the createTransport() function.
 
- * **AWSAccessKeyID** - AWS access key (required)
- * **AWSSecretKey** - AWS secret (required)
- * **ServiceUrl** - *optional* API end point URL (defaults to *"https://email.us-east-1.amazonaws.com"*)
- * **AWSSecurityToken** - *optional* security token
+  Possible SES options are the following:
+
+  * **accessKeyId** - *optional* AWS access key.
+  * **secretAccessKey** - *optional* AWS secret.
+  * **sessionToken** - *optional* session token.
+  * **region** - *optional* Specify the region to send the service request to. Default to *us-east-1*
+
+  Deprecated parameters. These are kept for backward compatibility reasons to support users of Nodemailer prior to v0.7. Any new development should use the new parameters above:
+
+ * **AWSAccessKeyID** - *optional* AWS access key. The option **accessKeyId** should be used instead.
+ * **AWSSecretKey** - *optional* AWS secret. The option **secretAccessKey** should be used instead.
+ * **ServiceUrl** - *optional* API end point URL (defaults to *"https://email.us-east-1.amazonaws.com"*). The option **region** should be used instead.
+ * **AWSSecurityToken** - *optional* security token. The option **sessionToken** should be used instead.
 
 Example:
 
@@ -343,6 +353,7 @@ var transport = nodemailer.createTransport("SES", {
     AWSSecretKey: "AWS/Secret/key"
 });
 ```
+**As of v0.7, ```sendmail()``` return only ```messageId``` instead of ```message```, ```response``` and ```messageID```**
 
 ### Setting up Sendmail
 

--- a/examples/example_ses.js
+++ b/examples/example_ses.js
@@ -4,9 +4,9 @@ var nodemailer = require('../lib/nodemailer'),
 
 // Create an Amazon SES transport object
 var transport = nodemailer.createTransport("SES", {
-        AWSAccessKeyID: "AWSACCESSKEY",
-        AWSSecretKey: "/AWS/SECRET",
-        ServiceUrl: "https://email.us-east-1.amazonaws.com" // optional
+        accessKeyId: "AWSACCESSKEY", // optional
+        secretAccessKey: "/AWS/SECRET", // optional
+        region: "us-east-1" // optional
     });
 
 console.log('SES Configured');

--- a/lib/engines/ses.js
+++ b/lib/engines/ses.js
@@ -2,38 +2,45 @@
 
 /*
  * This file is based on the original SES module for Nodemailer by dfellis
- * https://github.com/andris9/Nodemailer/blob/11fb3ef560b87e1c25e8bc15c2179df5647ea6f5/lib/engines/SES.js
- */
+* https://github.com/andris9/Nodemailer/blob/11fb3ef560b87e1c25e8bc15c2179df5647ea6f5/lib/engines/SES.js
+* and on the rewrite by andris9
+* https://github.com/andris9/Nodemailer/blob/3ac11ae9a9faf95aabd9bffb37ca702fe33105e4/lib/engines/ses.js
+*/
 
 // NB! Amazon SES does not allow unicode filenames on attachments!
 
-var http = require('http'),
-    https = require('https'),
-    crypto = require('crypto'),
-    urllib = require("url");
+var AWS = require('aws-sdk');
 
 // Expose to the world
 module.exports = SESTransport;
 
 /**
- * <p>Generates a Transport object for Amazon SES</p>
+ * <p>Generates a Transport object for Amazon SES with aws-sdk</p>
  *
  * <p>Possible options can be the following:</p>
  *
  * <ul>
- *     <li><b>AWSAccessKeyID</b> - AWS access key (required)</li>
- *     <li><b>AWSSecretKey</b> - AWS secret (required)</li>
- *     <li><b>ServiceUrl</b> - optional API endpoint URL (defaults to <code>"https://email.us-east-1.amazonaws.com"</code>)
+ *     <li><b>accessKeyId</b> - AWS access key (optional)</li>
+ *     <li><b>secretAccessKey</b> - AWS secret (optional)</li>
+ *     <li><b>region</b> - optional region (defaults to <code>"us-east-1"</code>)
  * </ul>
  *
  * @constructor
- * @param {Object} options Options object for the SES transport
+ * @param {Object} optional config parameter for the AWS SES service
  */
-function SESTransport(options){
-    this.options = options || {};
+function SESTransport(options) {
 
-    //Set defaults if necessary
-    this.options.ServiceUrl = this.options.ServiceUrl || "https://email.us-east-1.amazonaws.com";
+    var pattern = /(.*)email(.*)\.(.*).amazonaws.com/i,
+        result = pattern.exec(options.ServiceUrl);
+
+    this.options = options || {};
+    this.options.accessKeyId = options.accessKeyId || options.AWSAccessKeyID;
+    this.options.secretAccessKey = options.secretAccessKey || options.AWSSecretKey;
+    this.options.sessionToken = options.sessionToken || options.AWSSecurityToken;
+    this.options.apiVersion = '2010-12-01';
+    this.options.region = options.region || (result && result[3]) || 'us-east-1';
+
+    this.ses = new AWS.SES(this.options);
 }
 
 /**
@@ -42,19 +49,13 @@ function SESTransport(options){
  * @param {Object} emailMessage MailComposer object
  * @param {Function} callback Callback function to run when the sending is completed
  */
-SESTransport.prototype.sendMail = function(emailMessage, callback) {
-
+SESTransport.prototype.sendMail = function (emailMessage, callback) {
     // SES strips this header line by itself
     emailMessage.options.keepBcc = true;
 
-    //Check if required config settings set
-    if(!this.options.AWSAccessKeyID || !this.options.AWSSecretKey) {
-        return callback(new Error("Missing AWS Credentials"));
-    }
-
-    this.generateMessage(emailMessage, (function(err, email){
-        if(err){
-            return typeof callback == "function" && callback(err);
+    this.generateMessage(emailMessage, (function (err, email) {
+        if (err) {
+            return typeof callback === "function" && callback(err);
         }
         this.handleMessage(email, callback);
     }).bind(this));
@@ -66,181 +67,54 @@ SESTransport.prototype.sendMail = function(emailMessage, callback) {
  * @param {String} email Compiled raw e-mail as a string
  * @param {Function} callback Callback function to run once the message has been sent
  */
-SESTransport.prototype.handleMessage = function(email, callback) {
-    var request,
-        date = new Date(),
-        urlparts = urllib.parse(this.options.ServiceUrl),
-        pairs = {
-            'Action': 'SendRawEmail',
-            'RawMessage.Data': (new Buffer(email, "utf-8")).toString('base64'),
-            'Version': '2010-12-01',
-            'Timestamp': this.ISODateString(date)
-        };
-
-    if (this.options.AWSSecurityToken) {
-        pairs.SecurityToken = this.options.AWSSecurityToken;
-    }
-
-    var params = this.buildKeyValPairs(pairs),
-
-        reqObj = {
-            host: urlparts.hostname,
-            path: urlparts.path || "/",
-            method: "POST",
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'Content-Length': params.length,
-                'Date': date.toUTCString(),
-                'X-Amzn-Authorization':
-                    ['AWS3-HTTPS AWSAccessKeyID='+this.options.AWSAccessKeyID,
-                    "Signature="+this.buildSignature(date.toUTCString(), this.options.AWSSecretKey),
-                    "Algorithm=HmacSHA256"].join(",")
+SESTransport.prototype.handleMessage = function (email, callback) {
+    var params = {
+            RawMessage: { // required
+                Data: (new Buffer(email, "utf-8")).toString('base64') // required
             }
         };
-
-    //Execute the request on the correct protocol
-    if(urlparts.protocol.substr() == "https:") {
-        request = https.request(reqObj, this.responseHandler.bind(this, callback));
-    } else {
-        request = http.request(reqObj, this.responseHandler.bind(this, callback));
-    }
-    request.end(params);
-
-    // Handle fatal errors
-    request.on("error", this.errorHandler.bind(this, callback) );
+    this.ses.sendRawEmail(params, this.responseHandler.bind(this, callback));
 };
-
-
-
-/**
- * <p>Handles a fatal error response for the HTTP request to SES</p>
- *
- * @param {Function} callback Callback function to run on end (binded)
- * @param {Object} response HTTP Response object
- */
-SESTransport.prototype.errorHandler = function(callback, err) {
-    if( ! ( err instanceof Error) ) {
-        err = new Error('Email failed ' + ("statusCode" in err ? err.statusCode : null ), {response:err});
-    }
-    return typeof callback == "function" && callback(err, null);
-};
-
 
 /**
  * <p>Handles the response for the HTTP request to SES</p>
  *
  * @param {Function} callback Callback function to run on end (binded)
- * @param {Object} response HTTP Response object
+ * @param {Object} err Error object returned from the request
+ * @param {Object} data De-serialized data returned from the request
  */
-SESTransport.prototype.responseHandler = function(callback, response) {
-    var body = "", match;
-    response.setEncoding('utf8');
-
-    //Re-assembles response data
-    response.on('data', function(d) {
-        body += d.toString();
-    });
-
-    //Performs error handling and executes callback, if it exists
-    response.on('end', function(err) {
-        if(err instanceof Error) {
-            return typeof callback == "function" && callback(err, null);
+SESTransport.prototype.responseHandler = function (callback, err, data) {
+    if (err) {
+        if (!(err instanceof Error)) {
+            err = new Error('Email failed: ' + err);
         }
-        if(response.statusCode != 200) {
-            return typeof callback == "function" &&
-                callback(new Error('Email failed: ' + response.statusCode + '\n' + body), {
-                    message: body,
-                    response: response
-                });
-        }
-        match = (body || "").toString().match(/<MessageId\b[^>]*>([^<]+)<\/MessageId\b[^>]*>/i);
-        return typeof callback == "function" && callback(null, {
-            message: body,
-            response: response,
-            messageId: match && match[1] && match[1] + "@email.amazonses.com"
-        });
+        return typeof callback === "function" && callback(err, null);
+    }
+    return typeof callback === "function" && callback(null, {
+        messageId: data && data.MessageId && data.MessageId + "@email.amazonses.com"
     });
 };
 
 /**
  * <p>Compiles the messagecomposer object to a string.</p>
  *
- * <p>It really sucks but I don't know a good way to stream a POST request with
- * unknown legth, so the message needs to be fully composed as a string.</p>
+ * <p>SES requires strings as parameter so the message needs to be fully composed as a string.</p>
  *
  * @param {Object} emailMessage MailComposer object
  * @param {Function} callback Callback function to run once the message has been compiled
  */
 
-SESTransport.prototype.generateMessage = function(emailMessage, callback) {
+SESTransport.prototype.generateMessage = function (emailMessage, callback) {
     var email = "";
 
-    emailMessage.on("data", function(chunk){
+    emailMessage.on("data", function (chunk) {
         email += (chunk || "").toString("utf-8");
     });
 
-    emailMessage.on("end", function(chunk){
+    emailMessage.on("end", function (chunk) {
         email += (chunk || "").toString("utf-8");
         callback(null, email);
     });
 
     emailMessage.streamMessage();
-};
-
-/**
- * <p>Converts an object into a Array with "key=value" values</p>
- *
- * @param {Object} config Object with keys and values
- * @return {Array} Array of key-value pairs
- */
-SESTransport.prototype.buildKeyValPairs = function(config){
-    var keys = Object.keys(config).sort(),
-        keyValPairs = [],
-        key, i, len;
-
-    for(i=0, len = keys.length; i < len; i++) {
-        key = keys[i];
-        if(key != "ServiceUrl") {
-            keyValPairs.push((encodeURIComponent(key) + "=" + encodeURIComponent(config[key])));
-        }
-    }
-
-    return keyValPairs.join("&");
-};
-
-/**
- * <p>Uses SHA-256 HMAC with AWS key on date string to generate a signature</p>
- *
- * @param {String} date ISO UTC date string
- * @param {String} AWSSecretKey ASW secret key
- */
-SESTransport.prototype.buildSignature = function(date, AWSSecretKey) {
-    var sha256 = crypto.createHmac('sha256', AWSSecretKey);
-    sha256.update(date);
-    return sha256.digest('base64');
-};
-
-/**
- * <p>Generates an UTC string in the format of YYY-MM-DDTHH:MM:SSZ</p>
- *
- * @param {Date} d Date object
- * @return {String} Date string
- */
-SESTransport.prototype.ISODateString = function(d){
-    return d.getUTCFullYear() +             '-' +
-           this.strPad(d.getUTCMonth()+1) + '-' +
-           this.strPad(d.getUTCDate()) +    'T' +
-           this.strPad(d.getUTCHours()) +   ':' +
-           this.strPad(d.getUTCMinutes()) + ':' +
-           this.strPad(d.getUTCSeconds()) + 'Z';
-};
-
-/**
- * <p>Simple padding function. If the number is below 10, add a zero</p>
- *
- * @param {Number} n Number to pad with 0
- * @return {String} 0 padded number
- */
-SESTransport.prototype.strPad = function(n){
-    return n<10 ? '0'+n : n;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodemailer",
   "description": "Easy to use module to send e-mails, supports unicode and SSL/TLS",
-  "version": "0.6.5",
+  "version": "0.7",
   "author": "Andris Reinman",
   "maintainers": [
     {
@@ -29,7 +29,8 @@
     "simplesmtp": "~0.2 || ~0.3.30",
     "directmail": "~0.1.7",
     "he": "~0.3.6",
-    "public-address": "~0.1.1"
+    "public-address": "~0.1.1",
+    "aws-sdk": "~2.0.0"
   },
   "devDependencies": {
     "nodeunit": "*"


### PR DESCRIPTION
The new option use the aws-sdk node module that wraps
all the HTTP requests to SES servers. It allow the usage
of IAM roles instead of AWS credentials.
