### PR TITLE
Support passing mailcomposer `keepBcc` option

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -100,6 +100,10 @@ function Nodemailer(options){
     if(this.options.charset){
         mailcomposerOptions.charset = this.options.charset;
     }
+    
+    if(this.options.keepBcc){
+        mailcomposerOptions.keepBcc = this.options.keepBcc;
+    }
 
     if(!!this.options.forceEmbeddedImages){
         mailcomposerOptions.forceEmbeddedImages = true;


### PR DESCRIPTION
In my experience with Gmail SMTP, BCC's don't send unless included in the mail. `keepBcc` must be true or the BCC is ignored.
