### PR TITLE
Make the Date header RFC compliant.

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var transportHandler = require("./transport"),
+    emailDateHeader = require('email-date-header'),
     Transport = transportHandler.Transport,
     MailComposer = require("mailcomposer").MailComposer,
     XOAuthGenerator = require("./xoauth").XOAuthGenerator,
@@ -296,7 +297,8 @@ Nodemailer.prototype.setModuleHeaders = function(){
         transportOptions = this.transport &&
             this.transport.options &&
             typeof this.transport.options == "object" &&
-            this.transport.options || {};
+            this.transport.options || {},
+        dateOption = this.options.date;
 
     // Mailer name + version
     // if xMailer is explicitly set to false, skip the X-Mailer header
@@ -306,10 +308,10 @@ Nodemailer.prototype.setModuleHeaders = function(){
     }
 
     // Date
-    if(this.options.date){
-        this.mailcomposer.addHeader("Date", this.options.date);
+    if(dateOption){
+        this.mailcomposer.addHeader("Date", dateOption instanceof Date ? emailDateHeader(dateOption).value : dateOption);
     }else{
-        this.mailcomposer.addHeader("Date", new Date().toUTCString());
+        this.mailcomposer.addHeader("Date", emailDateHeader().value);
     }
 
     // Message ID

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "directmail": "~0.1.7",
     "he": "~0.3.6",
     "public-address": "~0.1.1",
-    "aws-sdk": "2.0.0-rc.20"
+    "aws-sdk": "2.0.0-rc.20",
+    "email-date-header": "~1.0.0"
   },
   "devDependencies": {
     "nodeunit": "*"

--- a/test/nodemailer.js
+++ b/test/nodemailer.js
@@ -1,4 +1,5 @@
 var testCase = require('nodeunit').testCase,
+    emailDateHeader = require('email-date-header'),
     nodemailer = require("../lib/nodemailer"),
     Transport = nodemailer.Transport,
     stripHTML = require("../lib/helpers").stripHTML,
@@ -95,6 +96,40 @@ exports["General tests"] = {
             test.ok(response.message.match(/Date:\s*Fri, 5 Nov 2012 09:41:00 -0800/));
             // default not present
             test.ok(!response.message.match(/^Date:\s*[0-9\s:a-yA-Y]+\s+GMT$/m));
+            test.done();
+        })
+    },
+
+    "Use an RFC compliant date when date is omitted in options": function(test){
+        var rfcCompliantDate = emailDateHeader().value;
+        var transport = nodemailer.createTransport("Stub"),
+            value = "a\r\n b\r\nc",
+            mailOptions = {
+                messageId: value,
+                headers: {'test-key': value}
+            };
+
+        transport.sendMail(mailOptions, function(error, response){
+            test.ifError(error);
+            test.ok(response.message.indexOf(rfcCompliantDate) > -1);
+            test.done();
+        })
+    },
+
+    "Use an RFC compliant date when Date instance is given in options": function(test){
+        var someDate = new Date(Date.now() + 90000000);
+        var rfcCompliantDate = emailDateHeader(someDate).value;
+        var transport = nodemailer.createTransport("Stub"),
+            value = "a\r\n b\r\nc",
+            mailOptions = {
+                messageId: value,
+                headers: {'test-key': value},
+                date: someDate
+            };
+
+        transport.sendMail(mailOptions, function(error, response){
+            test.ifError(error);
+            test.ok(response.message.indexOf(rfcCompliantDate) > -1);
             test.done();
         })
     },


### PR DESCRIPTION
While debugging some email using [this message linter](http://tools.ietf.org/tools/msglint/), I came across the
following warning:

`WARNING: old-style timezone in date in header 'Date' at line 1`

This led me to invstigate further and I then stumbled across [this](http://cr.yp.to/immhf/date.html):

```
There are two possibilities for the time zone:

* Numeric. An atom containing a sign and 4 digits. +hhmm means +(hh * 60 + mm) minutes, and -hhmm means -(hh * 60 + mm) minutes; mm is always between 00 and 59.
* Obsolete. One or two atoms, each starting with a letter. 822 specified the nicknames UT and GMT for +0000, EDT for -0400, EST and CDT for -0500, CST and MDT for -0600, MST and PDT for -0700, and PST for -0800. (822 also specified military nicknames for some zones, but it got them backwards; handling them would be pointless.) Many messages use other nicknames, violating 822. See below for a list of possibilities.
```

More on this [here](http://tools.ietf.org/html/rfc2822#section-4.3).
