### PR TITLE
Fixes spelling mistake, SMPT -> SMTP. Fixes #281

### DIFF
--- a/lib/wellknown.js
+++ b/lib/wellknown.js
@@ -161,7 +161,7 @@ module.exports = {
         domains: ['fastmail.fm']
     },
     "SendCloud": {
-        transport: "SMPT",
+        transport: "SMTP",
         host: "smtpcloud.sohu.com",
         port: 25,
         requiresAuth: true


### PR DESCRIPTION
There was a spelling mistake in the code; `SMTP` was spelled `SMPT`. This pull request fixes this and also closes issue #281.
