### PR TITLE
Clarifying TLS options in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,14 @@ Where
   * **options** defines connection data
     * **options.pool** if set to `true` uses pooled connections (defaults to `false`), otherwise creates a new connection for every e-mail.
     * **options.direct** if set to `true`, bypasses MTA relay and connects directly to recipients MX. Easier to set up but has higher chances of ending up in the Spam folder
-    * **options.service** can be set to the name of a well-known service so you don't have to input the `port`, `host`, and `secure` options (see [Using well-known services](#using-well-known-services)
+    * **options.service** can be set to the name of a well-known service so you don't have to input the `port`, `host`, and `secure` options (see [Using well-known services](#using-well-known-services))
     * **options.port** is the port to connect to (defaults to 25 or 465)
     * **options.host** is the hostname or IP address to connect to (defaults to `'localhost'`)
-    * **options.secure** defines if the connection should use SSL (if `true`) or not (if `false`). Set to `false` if you want to use STARTTLS
+    * **options.secure** if `true`the connection will only use TLS. If `false` (the default), TLS may still be upgraded to if available via the STARTTLS command. 
+    * **options.ignoreTLS** if this is `true` and `secure` is false, TLS will not be used (either to connect, or as a STARTTLS connection upgrade command).
+    * **options.tls** defines additional [node.js TLSSocket options](https://nodejs.org/api/tls.html#tls_class_tls_tlssocket) to be passed to the socket constructor, eg. *{rejectUnauthorized: true}*.
     * **options.auth** defines authentication data (see [authentication](#authentication) section below)
-    * **options.ignoreTLS** turns off STARTTLS support if true
+    * **options.authMethod** defines preferred authentication method, eg. 'PLAIN'
     * **options.name** optional hostname of the client, used for identifying to the server
     * **options.localAddress** is the local interface to bind to for network connections
     * **options.connectionTimeout** how many milliseconds to wait for the connection to establish
@@ -103,8 +105,6 @@ Where
     * **options.socketTimeout** how many milliseconds of inactivity to allow
     * **options.logger** optional [bunyan](https://github.com/trentm/node-bunyan) compatible logger instance. If set to `true` then logs to console. If value is not set or is `false` then nothing is logged
     * **options.debug** if set to true, then logs SMTP traffic, otherwise logs only transaction events
-    * **options.authMethod** defines preferred authentication method, eg. 'PLAIN'
-    * **options.tls** defines additional options to be passed to the socket constructor, eg. *{rejectUnauthorized: true}*
     * **options.maxConnections** available only if *pool* is set to `true`. (defaults to 5) is the count of maximum simultaneous connections to make against the SMTP server
     * **options.maxMessages** available only if *pool* is set to `true`. (defaults to 100) limits the message count to be sent using a single connection. After maxMessages messages the connection is dropped and a new one is created for the following messages
     * **options.rateLimit** available only if *pool* is set to `true`. (defaults to `false`) limits the message count to be sent in a second. Once rateLimit is reached, sending is paused until the end of the second. This limit is shared between connections, so if one connection uses up the limit, then other connections are paused as well


### PR DESCRIPTION
Making it clear what kind of connections are possible with combinations of `secure` and `ignoreTLS`. Also linking to TLS options in the node documentation.