### PR TITLE
Added Supporter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Send e-mails from Node.js – easy as cake! 🍰✉️
 
-<a href="https://gitter.im/nodemailer/nodemailer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://badges.gitter.im/Join Chat.svg" alt="Gitter chat" height="18"></a> <a href="http://travis-ci.org/nodemailer/nodemailer"><img src="https://secure.travis-ci.org/nodemailer/nodemailer.svg" alt="Build Status" height="18"></a> <a href="http://badge.fury.io/js/nodemailer"><img src="https://badge.fury.io/js/nodemailer.svg" alt="NPM version" height="18"></a> <a href="https://www.npmjs.com/package/nodemailer"><img src="https://img.shields.io/npm/dt/nodemailer.svg" alt="NPM downloads" height="18"></a>
+<a href="https://gitter.im/nodemailer/nodemailer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://badges.gitter.im/Join Chat.svg" alt="Gitter chat" height="18"></a> <a href="http://travis-ci.org/nodemailer/nodemailer"><img src="https://secure.travis-ci.org/nodemailer/nodemailer.svg" alt="Build Status" height="18"></a> <a href="http://badge.fury.io/js/nodemailer"><img src="https://badge.fury.io/js/nodemailer.svg" alt="NPM version" height="18"></a> <a href="https://www.npmjs.com/package/nodemailer"><img src="https://img.shields.io/npm/dt/nodemailer.svg" alt="NPM downloads" height="18"></a> <a href="https://supporter.60devs.com/support/bpyjm14k1icmklshopte49b5d/nodemailer"><img src="https://supporter.60devs.com/api/b/bpyjm14k1icmklshopte49b5d/nodemailer" alt="Support Nodemailer" height="18"></a>
 
 # Notes and information
 ## Nodemailer supports


### PR DESCRIPTION
Hi @andris9,

nodemailer is a great project. Thank you!

I am also running a project called Supporter which aims at helping open source projects get and maintain sustainable support. This PR adds a badge that we offer:

<a href="https://supporter.60devs.com/support/bpyjm14k1icmklshopte49b5d/nodemailer"><img src="https://supporter.60devs.com/api/b/bpyjm14k1icmklshopte49b5d/nodemailer" alt="Support Nodemailer" height="18"></a>

The badge link leads to the project payment page where the goals of the project are set. This helps users to understand how well the project is supported. And the badge shows the level of support in percents of the monthly project goal. The payment page is built on top of PayPal but unlike the normal donation page it supports recurring donations as well.  What do you think about it?

If you don't like the idea of adding another badge, just close this PR and I will remove the payment page from the website. But if you want to accept payments via this badge as well, you should sign in at our website using your Github account and specify the PayPal email address in your profile. Also you can see other projects that gave our badge a chance on our main page (for example, JSPM and WDRL).

Looking forward to hearing your feedback and best regards,
Oleksii

P.S. We are working on some new features which we hope will make donating more attractive and rewarding for those who donate. If you have some ideas in this direction, please let me know.