### PR TITLE
Fix return Promise in function sendMail

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -262,7 +262,8 @@ Nodemailer.prototype.sendMail = function (data, callback) {
     };
 
     if (typeof this.transporter === 'string') {
-        return callback(new Error('Unsupported configuration, downgrade Nodemailer to v0.7.1 to use it'));
+        callback(new Error('Unsupported configuration, downgrade Nodemailer to v0.7.1 to use it'));
+        return promise;
     }
 
     this.logger.info('Sending mail using %s/%s', this.transporter.name, this.transporter.version);


### PR DESCRIPTION
Return the promise instance even if throw a error. Or you will get a `TypeError` says `You may only yield a function, promise, generator, array, or object, but the following object was passed: "undefined"`.