### PR TITLE
fix(package): downgrade mailcomposer to 3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "libmime": "3.0.0",
-    "mailcomposer": "4.0.0",
+    "mailcomposer": "3.12.0",
     "nodemailer-direct-transport": "3.3.2",
     "nodemailer-shared": "1.1.0",
     "nodemailer-smtp-pool": "2.8.2",


### PR DESCRIPTION
mailcomposer 4.0.0 depends on buildmail 4.0.0 which depends on punycode 2.0.0 which requires Node >= 6 (https://github.com/bestiejs/punycode.js/releases/tag/v2.0.0).

If not Node 0.12 (as indicated on your website), Node 4 LTS should be supported.

If you wish to break the support, please do a major release of nodemailer.