### PR TITLE
Also ignore the npmignore file itself

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ test
 examples
 .eslintrc
 .gitignore
+.npmignore
 .travis.yml
 Gruntfile.js
 ISSUE_TEMPLATE.md


### PR DESCRIPTION
Unfortunately it is not ignored by default. Another option could be to add `files: ['lib', 'CHANGELOG.md']` to package.json and remove .npmignore.