### PR TITLE
Replace LICENSE with GitHub's MIT Template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2011-2017 Andris Reinman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -6,6 +8,9 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
A minor change but it makes it so that the GitHub UI picks up on the type of license being used and displays it in the repo. See here for their blog post on it: https://github.com/blog/2252-license-now-displayed-on-repository-overview

It's a little weird on how the license is identified, you usually need to include the "MIT License" which is one of the two changes, the other is just from GitHub's MIT template and up to you guys to decide on.

Enjoy 🎉