### PR TITLE
sendMail JSDoc fix: optional callback, Promise return

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -113,7 +113,8 @@ class Mail extends EventEmitter {
      * Sends an email using the preselected transport object
      *
      * @param {Object} data E-data description
-     * @param {Function} callback Callback to run once the sending succeeded or failed
+     * @param {Function} [callback] Callback to run once the sending succeeded or failed.
+     * @returns {Promise|undefined} Returns a promise if callback was not passed.
      */
     sendMail(data, callback) {
         let promise;


### PR DESCRIPTION
Hello! I am using Nodemailer for a long time, but recently I have migrated my project to use promises with `async/await`.

My IDE noted that you specified the callback a mandatory argument while it isn't. This pull request fixes the JSDoc.

Thank you.