### PR TITLE
Fix call toString on undefined/null

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -863,7 +863,7 @@ class SMTPConnection extends EventEmitter {
             notify = notify.join(',');
         }
 
-        let orcpt = (params.orcpt || params.recipient).toString() || null;
+        let orcpt = (params.orcpt || params.recipient || '').toString() || null;
         if (orcpt && orcpt.indexOf(';') < 0) {
             orcpt = 'rfc822;' + orcpt;
         }


### PR DESCRIPTION
Fix error: `Invalid DSN Cannot read property 'toString' of undefined`