### PR TITLE
Please enable the issues page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you are running the code in your own machine, then check your antivirus setti
 
 If you are having issues with Nodemailer, then the best way to find help would be [Stack Overflow](https://stackoverflow.com/search?q=nodemailer).
 
+### ROADMAP?
+
 ### License
 
 Nodemailer is licensed under the **MIT license**


### PR DESCRIPTION
Stack Overflow is great for answering user question and issue that might be on their-end.
However, I believe that any OSS projet needs an open issues page in order to discuss **potential improvements & bugs**.
Has the team any interest in making the project move forward?

Here is my early motivation for the PR. Nodemailer is incompatible with the `promisify` function of node:

**Do not work**
```js
import { promisify } from 'util'
import nodemailer from 'nodemailer'
const sentMail = await promisify(transporter.sendMail)(mailOptions)
```

**Work**
```js
import { promisify } from 'util'
import nodemailer from 'nodemailer'
import crypto from 'crypto'
const token = await promisify(crypto.randomBytes)(20)

const sentMail = await new Promise((accept, reject) => {
  transporter.sendMail(mailOptions, (err, info) => {
    if (err) {
      reject(err)
      return
    }
    accept(info)
  })
})
```