### PR TITLE
Add Node.js v8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - 6
   - 7
+  - 8
 notifications:
   email:
     - andris@kreata.ee


### PR DESCRIPTION
Add support for Node.js v8.
Updated .travis.yml.