### PR TITLE
Update jsdoc

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -113,7 +113,7 @@ class Mail extends EventEmitter {
      * Sends an email using the preselected transport object
      *
      * @param {Object} data E-data description
-     * @param {Function} callback Callback to run once the sending succeeded or failed
+     * @param {Function?} callback Callback to run once the sending succeeded or failed
      */
     sendMail(data, callback) {
         let promise;


### PR DESCRIPTION
Since callback is optional and we can skip it, when we use nodemailer in a promise way, we don't want IDEs to warn us about missing arguments.