### PR TITLE
Added mailtrap as a well known service

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -135,7 +135,7 @@
     "Mailtrap": {
         "host": "smtp.mailtrap.io",
         "port": 2525
-    }
+    },
 
     "Mandrill": {
         "host": "smtp.mandrillapp.com",

--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -131,6 +131,11 @@
         "host": "mailosaur.io",
         "port": 25
     },
+    
+    "Mailtrap": {
+        "host": "smtp.mailtrap.io",
+        "port": 2525
+    }
 
     "Mandrill": {
         "host": "smtp.mandrillapp.com",


### PR DESCRIPTION
Mailtrap is a well known service for developers to test emails that seemed worth adding for quick configuration.