### PR TITLE
Add Reply-To header Capability for SMTP Transport

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -779,6 +779,9 @@ class SMTPConnection extends EventEmitter {
 
         this._envelope = envelope || {};
         this._envelope.from = ((this._envelope.from && this._envelope.from.address) || this._envelope.from || '').toString().trim();
+        if("replyTo" in this._envelope) {
+            this._envelope.replyTo = ((this._envelope.replyTo && this._envelope.replyTo.address) || this._envelope.replyTo || '').toString().trim();
+        }
 
         this._envelope.to = [].concat(this._envelope.to || []).map(to => ((to && to.address) || to || '').toString().trim());
 
@@ -856,6 +859,9 @@ class SMTPConnection extends EventEmitter {
         }
 
         this._sendCommand('MAIL FROM:<' + this._envelope.from + '>' + (args.length ? ' ' + args.join(' ') : ''));
+        if("replyTo" in this._envelope) {
+            this._sendCommand('REPLY-TO:<' + this._envelope.replyTo + '>');
+        }
     }
 
     _setDsnEnvelope(params) {


### PR DESCRIPTION
I could not find documentation (perhaps I didn't look hard enough) on how to use the default SMTP transport to do the Reply-To header, and I couldn't see anything in the code that implemented the `REPLY-TO:` command.

This adds a `replyTo` optional parameter to the envelope and sends a `REPLY-TO` command after the `MAIL FROM` command.

I can add comments above the functions at lines 776 and 381, but I wasn't sure if you wanted to direct that yourselves.