### PR TITLE
Fix reporting error for incomplete credentials

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -330,7 +330,7 @@ class SMTPConnection extends EventEmitter {
             this._authMethod = (this._supportedAuth[0] || 'PLAIN').toUpperCase().trim();
         }
 
-        if (this._authMethod !== 'XOAUTH2' && !this._auth.credentials) {
+        if (this._authMethod !== 'XOAUTH2' && (!this._auth.credentials || !this._auth.credentials.user || !this._auth.credentials.pass)) {
             if (this._auth.user && this._auth.pass) {
                 this._auth.credentials = {
                     user: this._auth.user,

--- a/test/smtp-connection/smtp-connection-test.js
+++ b/test/smtp-connection/smtp-connection-test.js
@@ -626,6 +626,44 @@ describe('SMTP-Connection Tests', function() {
             );
         });
 
+        it('should return error for missing credentials', function(done) {
+            expect(client.authenticated).to.be.false;
+            client.login(
+                {
+                    user: 'testuser'
+                },
+                function(err) {
+                    expect(err).to.exist;
+                    expect(client.authenticated).to.be.false;
+                    expect(err.message).to.match(/^Missing credentials/);
+                    expect(err.code).to.equal('EAUTH');
+                    expect(err.response).to.be.undefined;
+                    done();
+                }
+            );
+        });
+
+        it('should return error for incomplete credentials', function(done) {
+            expect(client.authenticated).to.be.false;
+            client.login(
+                {
+                    user: 'testuser',
+                    credentials: {
+                        user: 'testuser'
+                    }
+                },
+                function(err) {
+                    expect(err).to.exist;
+                    expect(client.authenticated).to.be.false;
+                    expect(err.message).to.match(/^Missing credentials/);
+                    expect(err.code).to.equal('EAUTH');
+                    expect(err.response).to.be.undefined;
+                    done();
+                }
+            );
+        });
+
+
         describe('xoauth2 login', function() {
             this.timeout(10 * 1000);
             let x2server;


### PR DESCRIPTION
- Add test for completely missing credentials
- Add test for partially missing credentials (eg. user is defined, but
  password is missing)
- Fix reporting "Missing credentials" error for only partially defined
  credentials

Reasons for this change are motivated by my own "stupid user mistake" when I tried to configure SMTP transport using `password` as a credential property name instead of `pass`. 😉

Before this change Nodemailer would have tried to authenticate using `undefined` as pass reporting invalid login from SMTP server.

This will add credentials validation and report error "Missing credentials" error before SMTP server is called, so hopefully future users making same mistakes would recover from them a little faster than I. 😄 