### PR TITLE
return promise when using cached testAccount

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -69,7 +69,8 @@ module.exports.createTestAccount = function(apiUrl, callback) {
     }
 
     if (testAccount) {
-        return callback(null, testAccount);
+        callback(null, testAccount);
+        return promise;
     }
 
     apiUrl = apiUrl || ETHEREAL_API;

--- a/test/ethereal-test.js
+++ b/test/ethereal-test.js
@@ -42,4 +42,24 @@ describe('Ethereal Tests', function() {
             });
         });
     });
+
+    it('should cache a created test account', function(done) {
+        nodemailer.createTestAccount((err, account) => {
+            expect(err).to.not.exist;
+            nodemailer.createTestAccount((err, account2) => {
+                expect(err).to.not.exist;
+                expect(account2).to.equal(account);
+                done();
+            });
+        });
+    });
+
+    it('should cache a created test account when using promises', function(done) {
+        nodemailer.createTestAccount().then(account => {
+            nodemailer.createTestAccount().then(account2 => {
+                expect(account2).to.equal(account);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
When using promises, the second call to `createTestAccount` returns `undefined`.