### PR TITLE
Support v2 of the socks module

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -333,13 +333,7 @@ class Mail extends EventEmitter {
                                 host: options.host,
                                 port: options.port
                             },
-                            command: 'connect',
-                            authentication: !proxy.auth
-                                ? false
-                                : {
-                                    username: decodeURIComponent(proxy.auth.split(':').shift()),
-                                    password: decodeURIComponent(proxy.auth.split(':').pop())
-                                }
+                            command: 'connect'
                         }, (err, socket) => {
                             if (err) {
                                 return callback(err);

--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -321,25 +321,24 @@ class Mail extends EventEmitter {
                     if (!this.meta.has('proxy_socks_module')) {
                         return callback(new Error('Socks module not loaded'));
                     }
-
                     let connect = ipaddress => {
                         this.meta.get('proxy_socks_module').createConnection({
                             proxy: {
                                 ipaddress,
-                                port: proxy.port,
+                                port: proxy.port * 1,
                                 type: Number(proxy.protocol.replace(/\D/g, '')) || 5
                             },
-                            target: {
+                            destination: {
                                 host: options.host,
                                 port: options.port
                             },
                             command: 'connect'
-                        }, (err, socket) => {
+                        }, (err, info) => {
                             if (err) {
                                 return callback(err);
                             }
                             return callback(null, {
-                                connection: socket
+                                connection: info.socket
                             });
                         });
                     };


### PR DESCRIPTION
There's now v2 of the [socks-module](https://www.npmjs.com/package/socks) which seems the preferred for node >=v6.0.

However, the API has changed, `target` is now `destination` and the callback for `createConnection` gets an Object instead of the socket directly. In addition, casting `proxy.port` to number is required, as socks checks this when connecting.

I also removed the authentication part, because I have no quick and easy way to test it, and the docs from v1
state it should've been in the `proxy`-object?

Lastly, for this to work, the [docs](https://nodemailer.com/smtp/proxies/#2-using-socks-proxy) should be updated:
`transporter.set('proxy_socks_module', require('socks'));`
should be
`transporter.set('proxy_socks_module', require('socks').SocksClient);`

Thank you very much for a great lib!

