### PR TITLE
Don’t turn TO:<root> into TO:<@root>

### DIFF
--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -1138,6 +1138,10 @@ class MimeNode {
         address = (address || '').toString().trim();
 
         let lastAt = address.lastIndexOf('@');
+        if (lastAt < 0) {
+            // Bare username
+            return address;
+        }
         let user = address.substr(0, lastAt);
         let domain = address.substr(lastAt + 1);
 

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -1046,6 +1046,20 @@ describe('MimeNode Tests', function() {
                     name: 'test'
                 }
             ]);
+
+            expect(
+                mb._parseAddresses([
+                    {
+                        address: 'root',
+                        name: 'Charlie Root'
+                    }
+                ])
+            ).to.deep.equal([
+                {
+                    address: 'root',
+                    name: 'Charlie Root'
+                }
+            ]);
         });
     });
 


### PR DESCRIPTION
Thanks for writing nodemailer. I’m finding the code using it to be a lot shorter than the Python I’m porting it from, and it’s really nice that nodemailer works with TLS out of the box.

Right now, nodemailer errors when sending mail to a bare username. This can happen on UNIX hosts with local mail spools where one user or script sends mail to another user, or to root.

When I try to send mail to `Administrator <root>`, nodemailer turns that into `<@root>` which the SMTP server rejects with `Relay access denied`. This PR would fix that.

When I try to send mail to `root`, nodemailer errors out with `Send Error: No recipients defined`. If you’re interesting in fixing that, it would require a change in the [semantics of addressparser][].

Please let me know if you’re interested in either or both changes.

[semantics of addressparser]: https://github.com/nodemailer/nodemailer/blob/940f6e9a2178ed4861757b389257a22e72885b1c/test/addressparser/addressparser-test.js#L211-L220