### PR TITLE
Allow chaining of `.use` calls

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -123,6 +123,8 @@ class Mail extends EventEmitter {
         } else {
             this._userPlugins[step].push(plugin);
         }
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
This allows for easier plugin configuration:
```js
createTransport()
  .use(...)
  .sendMail(...)
```

Apologies for not adding a test, but I didn't see anywhere where `.use` was exercised.