### PR TITLE
StreamTransport class shouldn't be called `SendmailTransport`

### DIFF
--- a/lib/stream-transport/index.js
+++ b/lib/stream-transport/index.js
@@ -16,7 +16,7 @@ const LeUnix = require('../sendmail-transport/le-unix');
  * @constructor
  * @param {Object} optional config parameter for the AWS Sendmail service
  */
-class SendmailTransport {
+class StreamTransport {
     constructor(options) {
         options = options || {};
 
@@ -139,4 +139,4 @@ class SendmailTransport {
     }
 }
 
-module.exports = SendmailTransport;
+module.exports = StreamTransport;


### PR DESCRIPTION
I assume this was a copy-paste error 😄 