### PR TITLE
Use first IP address from DNS resolution when using a proxy.

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -374,7 +374,7 @@ class Mail extends EventEmitter {
                         if (err) {
                             return callback(err);
                         }
-                        connect(address);
+                        connect(Array.isArray(address) ? address[0] : address);
                     });
                 }
             }


### PR DESCRIPTION
When using a proxy URL with a hostname (e.g. _socks5://myproxy:1080_), Nodemailer does resolve the name. The resolution result is an IP address array, however Nodemailer interprets it as a string.

This patch checks whether the resolution result is an array and uses the first element (IP). Otherwise the value is forwarded.

Bug discovered with Node v8.9.3 and Nodemailer 4.6.7.