### PR TITLE
(fix: memory leak: #979): destroy the opened socket on destructor

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -842,6 +842,7 @@ class SMTPConnection extends EventEmitter {
         if (this._destroyed) {
             return;
         }
+        this._socket.destroy();
         this._destroyed = true;
         this.emit('end');
     }


### PR DESCRIPTION
The socket in the smtp connection does not destroy on its own, which creates a memory leak.
https://github.com/nodemailer/nodemailer/issues/979