### PR TITLE
(fix: memory leak: #979): save the end and the close listeners for socket

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -682,11 +682,9 @@ class SMTPConnection extends EventEmitter {
 
         this.stage = 'connected';
 
-        // clear existing listeners for the socket
+        // we can safely keep 'error', 'end', 'close' etc. events
         this._socket.removeAllListeners('data');
         this._socket.removeAllListeners('timeout');
-        this._socket.removeAllListeners('close');
-        this._socket.removeAllListeners('end');
 
         this._socket.on('data', chunk => this._onData(chunk));
         this._socket.once('close', errored => this._onClose(errored));


### PR DESCRIPTION
The socket already has an onReadableStreamEnd listener for the end event. If we call removeAllListeners('end'), then the stream will never end, and the close event is never called for this socket.