### PR TITLE
Allow passing http headers when fetching attachments

### DIFF
--- a/lib/mail-composer/index.js
+++ b/lib/mail-composer/index.js
@@ -128,7 +128,8 @@ class MailComposer {
                 };
             } else if (attachment.href) {
                 data.content = {
-                    href: attachment.href
+                    href: attachment.href,
+                    httpHeaders: attachment.httpHeaders
                 };
             } else {
                 data.content = attachment.content || '';

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -971,7 +971,7 @@ class MimeNode {
                 return contentStream;
             }
             // fetch URL
-            return fetch(content.href);
+            return fetch(content.href, { headers: content.httpHeaders });
         } else {
             // pass string or buffer content as a stream
             contentStream = new PassThrough();


### PR DESCRIPTION
This PR allows to pass a set of `httpHeaders` to be sent when fetching attachments. In my case my files are not publicly available and I need to send a `Bearer` token in the `Authorization` header to be able to retrieve them.