### PR TITLE
preserve whitespace in quotes

### DIFF
--- a/lib/addressparser/index.js
+++ b/lib/addressparser/index.js
@@ -143,6 +143,7 @@ class Tokenizer {
         this.str = (str || '').toString();
         this.operatorCurrent = '';
         this.operatorExpecting = '';
+        this.whiteSpacePreserve = false;
         this.node = null;
         this.escaped = false;
 
@@ -151,18 +152,18 @@ class Tokenizer {
          * Operator tokens and which tokens are expected to end the sequence
          */
         this.operators = {
-            '"': '"',
-            '(': ')',
-            '<': '>',
-            ',': '',
-            ':': ';',
+            '"': { wsp: true, close: '"' },
+            '(': { wsp: false, close: ')' },
+            '<': { wsp: false, close: '>' },
+            ',': { wsp: false, close: '' },
+            ':': { wsp: false, close: ';' },
             // Semicolons are not a legal delimiter per the RFC2822 grammar other
             // than for terminating a group, but they are also not valid for any
             // other use in this context.  Given that some mail clients have
             // historically allowed the semicolon as a delimiter equivalent to the
             // comma in their UI, it makes sense to treat them the same as a comma
             // when used outside of a group.
-            ';': ''
+            ';': { wsp: false, close: '' }
         };
     }
 
@@ -178,9 +179,11 @@ class Tokenizer {
             chr = this.str.charAt(i);
             this.checkChar(chr);
         }
-
         this.list.forEach(node => {
-            node.value = (node.value || '').toString().trim();
+            node.value = (node.value || '').toString();
+            if (!node.wsp) {
+              node.value = node.value.trim();
+            }
             if (node.value) {
                 list.push(node);
             }
@@ -206,6 +209,7 @@ class Tokenizer {
             this.node = null;
             this.operatorExpecting = '';
             this.escaped = false;
+            this.whiteSpacePreserve = false;
             return;
         } else if (!this.operatorExpecting && chr in this.operators) {
             this.node = {
@@ -214,7 +218,8 @@ class Tokenizer {
             };
             this.list.push(this.node);
             this.node = null;
-            this.operatorExpecting = this.operators[chr];
+            this.operatorExpecting = this.operators[chr].close;
+            this.whiteSpacePreserve = this.operators[chr].wsp;
             this.escaped = false;
             return;
         }
@@ -227,7 +232,8 @@ class Tokenizer {
         if (!this.node) {
             this.node = {
                 type: 'text',
-                value: ''
+                value: '',
+                wsp: this.whiteSpacePreserve
             };
             this.list.push(this.node);
         }

--- a/test/addressparser/addressparser-test.js
+++ b/test/addressparser/addressparser-test.js
@@ -58,6 +58,17 @@ describe('#addressparser', function() {
         expect(addressparser(input)).to.deep.equal(expected);
     });
 
+    it('should handle whitespace in quoted name correctly', function() {
+        let input = '"reinman, trailspace " <andris@tr.ee>';
+        let expected = [
+            {
+                name: 'reinman, trailspace ',
+                address: 'andris@tr.ee'
+            }
+        ];
+        expect(addressparser(input)).to.deep.equal(expected);
+    });
+
     it('should handle quoted semicolons correctly', function() {
         let input = '"reinman; andris" <andris@tr.ee>';
         let expected = [


### PR DESCRIPTION
In support of pull request mailparser#231 which addresses certain address encoding pattern support.

So mailparser has tests that expect this to work this way - if there's a whitespace in your quotes, it keeps it. Its not unreasonable. This adds a state to the address parser struct so it can maintain that. If that's not wanted, okay, we can just remove the space tests in mailparser instead.

I debated with myself at some length about whether addressparser belongs in mailparser or in nodemailer or neither. It really is kind of stinky to have to update nodemailer to support a test that previously existed only in mailparser.  You need to parse addresses in both so, maybe there should (in best case) be an addressparser module that can be included by both of them :?
