### PR TITLE
smtp-connection: Ignore "end" events because it might be "error" after it

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -189,7 +189,6 @@ class SMTPConnection extends EventEmitter {
         this._onSocketData = (chunk) => this._onData(chunk);
         this._onSocketError = (error) => this._onError(error, 'ESOCKET', false, 'CONN');
         this._onSocketClose = () => this._onClose();
-        this._onSocketEnd = () => this._onEnd();
         this._onSocketTimeout = () => this._onTimeout();
     }
 
@@ -693,11 +692,9 @@ class SMTPConnection extends EventEmitter {
         this._socket.removeListener('data', this._onSocketData);
         this._socket.removeListener('timeout', this._onSocketTimeout);
         this._socket.removeListener('close', this._onSocketClose);
-        this._socket.removeListener('end', this._onSocketEnd);
 
         this._socket.on('data', this._onSocketData);
         this._socket.once('close', this._onSocketClose);
-        this._socket.once('end', this._onSocketEnd);
 
         this._socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT);
         this._socket.on('timeout', this._onSocketTimeout);
@@ -825,15 +822,6 @@ class SMTPConnection extends EventEmitter {
     }
 
     /**
-     * 'end' listener for the socket
-     *
-     * @event
-     */
-    _onEnd() {
-        this._destroy();
-    }
-
-    /**
      * 'timeout' listener for the socket
      *
      * @event
@@ -886,7 +874,6 @@ class SMTPConnection extends EventEmitter {
                 this._socket.on('data', this._onSocketData);
 
                 socketPlain.removeListener('close', this._onSocketClose);
-                socketPlain.removeListener('end', this._onSocketEnd);
 
                 return callback(null, true);
             }
@@ -894,7 +881,6 @@ class SMTPConnection extends EventEmitter {
 
         this._socket.on('error', this._onSocketError);
         this._socket.once('close', this._onSocketClose);
-        this._socket.once('end', this._onSocketEnd);
 
         this._socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT); // 10 min.
         this._socket.on('timeout', this._onSocketTimeout);

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -831,7 +831,7 @@ class SMTPConnection extends EventEmitter {
      */
     _onEnd() {
         if (this._socket && !this._socket.destroyed) {
-            this._socket.close()
+            this._socket.destroy()
         }
     }
 

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -189,6 +189,7 @@ class SMTPConnection extends EventEmitter {
         this._onSocketData = (chunk) => this._onData(chunk);
         this._onSocketError = (error) => this._onError(error, 'ESOCKET', false, 'CONN');
         this._onSocketClose = () => this._onClose();
+        this._onSocketEnd = () => this._onEnd();
         this._onSocketTimeout = () => this._onTimeout();
     }
 
@@ -692,9 +693,11 @@ class SMTPConnection extends EventEmitter {
         this._socket.removeListener('data', this._onSocketData);
         this._socket.removeListener('timeout', this._onSocketTimeout);
         this._socket.removeListener('close', this._onSocketClose);
+        this._socket.removeListener('end', this._onSocketEnd);
 
         this._socket.on('data', this._onSocketData);
         this._socket.once('close', this._onSocketClose);
+        this._socket.once('end', this._onSocketEnd);
 
         this._socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT);
         this._socket.on('timeout', this._onSocketTimeout);
@@ -822,6 +825,17 @@ class SMTPConnection extends EventEmitter {
     }
 
     /**
+     * 'end' listener for the socket
+     *
+     * @event
+     */
+    _onEnd() {
+        if (this._socket && !this._socket.destroyed) {
+            this._socket.close()
+        }
+    }
+
+    /**
      * 'timeout' listener for the socket
      *
      * @event
@@ -874,6 +888,7 @@ class SMTPConnection extends EventEmitter {
                 this._socket.on('data', this._onSocketData);
 
                 socketPlain.removeListener('close', this._onSocketClose);
+                socketPlain.removeListener('end', this._onSocketEnd);
 
                 return callback(null, true);
             }
@@ -881,6 +896,7 @@ class SMTPConnection extends EventEmitter {
 
         this._socket.on('error', this._onSocketError);
         this._socket.once('close', this._onSocketClose);
+        this._socket.once('end', this._onSocketEnd);
 
         this._socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT); // 10 min.
         this._socket.on('timeout', this._onSocketTimeout);

--- a/test/smtp-connection/smtp-connection-test.js
+++ b/test/smtp-connection/smtp-connection-test.js
@@ -49,7 +49,6 @@ describe('SMTP-Connection Tests', function() {
                     stream.on('data', function() {});
                     stream.on('end', callback);
                 },
-                logger: false
             });
 
             insecureServer = new SMTPServer({
@@ -214,7 +213,7 @@ describe('SMTP-Connection Tests', function() {
             client.on('end', done);
         });
 
-        it('should receive end after STARTTLS', function(done) {
+        it('should close connection after STARTTLS', function(done) {
             let client = new SMTPConnection({
                 port: PORT_NUMBER,
                 logger: false
@@ -228,7 +227,7 @@ describe('SMTP-Connection Tests', function() {
             });
 
             client.on('error', function(err) {
-                expect(err).to.not.exist;
+                expect(err.message).to.equal("Connection closed unexpectedly");
             });
 
             client.on('end', done);

--- a/test/smtp-pool/smtp-pool-test.js
+++ b/test/smtp-pool/smtp-pool-test.js
@@ -330,7 +330,9 @@ describe('SMTP Pool Tests', function() {
                     )
                 },
                 function(err) {
-                    expect(err).to.not.exist;
+                    if (err) {
+                        expect(err.message).to.equal("Connection closed unexpectedly");
+                    }
                     callback();
                 }
             );


### PR DESCRIPTION
Hi.

I found some general problem in smtp-connection module.

It listens for `end` event and then it marks than connection is closed when it comes. But the specification for sockets is that `end` is not a last event. It marks just a half-closed state and then it might come `error` and finally `close`.

First problem is that Nodemailer can leak sockets: they still there in half-open state and nobody will close them. I found this issue in my production environment when after 1 day I had more than 100K opened sockets without any good reason. Then I made some workaround that I send a opened socket as a parameter to `SMTPConnection` as a `connection` argument and I handle events by my own.

Now I understand what was the root cause and I'm pretty sure that bug existed in Nodemailer library for a long time.

This issue is pretty obvious for STARTTLS. If the server doesn't support TLS but `requireTLS: true` is used then the order of events coming to Nodemailer are: `end`, then `error`, then `close`. Nodemailer catches `end` as first and then ignores following `error` and `close`. Finally, the user gets no error because callback returns success for this operation even if it was failed.

So I think the right solution is to ignore `end` events as it is not so useful as it should be and to handle only `close` and `error` events.

Edit:

It is better to explicitly close half-ended socket rather than to ignore it.
