### PR TITLE
Support connection refused dns error

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -19,6 +19,7 @@ const resolver = (family, hostname, callback) => {
                 case dns.NOTFOUND:
                 case dns.NOTIMP:
                 case dns.SERVFAIL:
+                case dns.CONNREFUSED:
                 case 'EAI_AGAIN':
                     return callback(null, []);
             }


### PR DESCRIPTION
## Summary
There seems to be a case where the following error occurs when trying to resolve the host name.

```js
{ Error: queryA ECONNREFUSED smtp.mail.yahoo.co.jp
    at QueryReqWrap.onresolve [as oncomplete] (dns.js:197:19)
  errno: 'ECONNREFUSED',
  code: 'EDNS',
  syscall: 'queryA',
  hostname: 'smtp.mail.yahoo.co.jp',
  command: 'CONN' }
```

### Environment
- nodejs-mobile@10.13.0 (android)
- nodemailer@6.3.1

### sample code
```js
const nodemailer = require('../lib/nodemailer');

async function main() {
    // Create a SMTP transporter object
    var smtpOptions = {
        host: "smtp.mail.yahoo.co.jp",
        port: 465,
        secure: true
    };
    smtpOptions.auth = {
            user: "***@yahoo.co.jp",
            pass: "***"
    };
    let transporter;
    try{
        console.log("createTransport");
        let transporter = nodemailer.createTransport(smtpOptions);
        transporter.to = "***@yahoo.co.jp";    
        // Message object
        let message = {
            from: 'hiroyuki okada <****@yahoo.co.jp>',
            // Comma separated list of recipients
            to: 'hiroyuki okada <***@***.com>',
            // Subject of the message
            subject: 'Nodemailer is unicode friendly ✔',
            // plaintext body
            text: 'Hello to myself!'
        };
        console.log("sendMail");
        let info = await transporter.sendMail(message);
        console.log('Message sent successfully as %s', info.messageId);            
    }catch(e){
        console.log(e);
    }
}

main();
```

## Proposed changes
add dns.CONNREFUSED to resolver function.

```js
const resolver = (family, hostname, callback) => {
    dns['resolve' + family](hostname, (err, addresses) => {
        if (err) {
            switch (err.code) {
                case dns.NODATA:
                case dns.NOTFOUND:
                case dns.NOTIMP:
                case dns.SERVFAIL:
                case dns.CONNREFUSED:  //add
                case 'EAI_AGAIN':
                    return callback(null, []);
            }
            return callback(err);
        }
        return callback(null, Array.isArray(addresses) ? addresses : [].concat(addresses || []));
    });
};
```