### PR TITLE
Allowing user and pass to be empty strings for SMTP auth

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -437,7 +437,7 @@ class SMTPConnection extends EventEmitter {
             this._authMethod = (this._supportedAuth[0] || 'PLAIN').toUpperCase().trim();
         }
 
-        if (this._authMethod !== 'XOAUTH2' && (!this._auth.credentials || !this._auth.credentials.user || !this._auth.credentials.pass)) {
+        if (this._authMethod !== 'XOAUTH2' && (!this._auth.credentials || (this._auth.credentials.user == null) || (this._auth.credentials.pass == null))) {
             if (this._auth.user && this._auth.pass) {
                 this._auth.credentials = {
                     user: this._auth.user,


### PR DESCRIPTION
This allows you to create an SMTP transport that has its auth user and/or password set to empty strings.

I've encountered a scenario where an internal SMTP server is configured to have a password configured as "" but still require a valid user to be provided. Without this change I can't send  emails via this server (would just get "Missing credentials" error).