### PR TITLE
#1105 add max number of requeues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "eslint.enable": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.enable": false
+}

--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -416,11 +416,11 @@ class SMTPPool extends EventEmitter {
     }
 
     _shouldRequeuOnConnectionClose(queueEntry) {
-      if (this.options.maxRequeues === undefined || this.options.maxRequeues < 0) {
-        return true;
-      }
+        if (this.options.maxRequeues === undefined || this.options.maxRequeues < 0) {
+            return true;
+        }
 
-      return queueEntry.requeueAttempts && queueEntry.requeueAttempts < this.options.maxRequeues;
+        return queueEntry.requeueAttempts && queueEntry.requeueAttempts < this.options.maxRequeues;
     }
 
     _failDeliveryOnConnectionClose(connection) {
@@ -445,8 +445,8 @@ class SMTPPool extends EventEmitter {
     };
 
     _requeueEntryOnConnectionClose(connection) {
-      connection.queueEntry.requeueAttempts = connection.queueEntry.requeueAttempts + 1;
-      this.logger.debug(
+        connection.queueEntry.requeueAttempts = connection.queueEntry.requeueAttempts + 1;
+        this.logger.debug(
             {
                 tnx: 'pool',
                 cid: connection.id,

--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -445,16 +445,18 @@ class SMTPPool extends EventEmitter {
     };
 
     _requeueEntryOnConnectionClose(connection) {
-        this.logger.debug(
+      connection.queueEntry.requeueAttempts = connection.queueEntry.requeueAttempts + 1;
+      this.logger.debug(
             {
                 tnx: 'pool',
                 cid: connection.id,
                 messageId: connection.queueEntry.messageId,
                 action: 'requeue'
             },
-            'Re-queued message <%s> for #%s',
+            'Re-queued message <%s> for #%s. Attempt: #%s',
             connection.queueEntry.messageId,
-            connection.id
+            connection.id,
+            connection.queueEntry.requeueAttempts;
         );
         this._queue.unshift(connection.queueEntry);
         connection.queueEntry = false;

--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -1,4 +1,4 @@
-
+'use strict';
 
 const EventEmitter = require('events');
 const PoolResource = require('./pool-resource');

--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -103,6 +103,7 @@ class SMTPPool extends EventEmitter {
 
         this._queue.push({
             mail,
+            requeueAttempts: 0,
             callback
         });
 
@@ -391,23 +392,16 @@ class SMTPPool extends EventEmitter {
 
             if (connection.queueEntry) {
                 // If the connection closed when sending, add the message to the queue again
+                // if max number of requeues is not reached yet
                 // Note that we must wait a bit.. because the callback of the 'error' handler might be called
                 // in the next event loop
                 setTimeout(() => {
                     if (connection.queueEntry) {
-                        this.logger.debug(
-                            {
-                                tnx: 'pool',
-                                cid: connection.id,
-                                messageId: connection.queueEntry.messageId,
-                                action: 'requeue'
-                            },
-                            'Re-queued message <%s> for #%s',
-                            connection.queueEntry.messageId,
-                            connection.id
-                        );
-                        this._queue.unshift(connection.queueEntry);
-                        connection.queueEntry = false;
+                        if (this._shouldRequeuOnConnectionClose(connection.queueEntry)) {
+                            this._requeueEntryOnConnectionClose(connection)
+                        } else {
+                            this._failDeliveryOnConnectionClose(connection);
+                        } 
                     }
                     this._continueProcessing();
                 }, 50);
@@ -419,6 +413,51 @@ class SMTPPool extends EventEmitter {
         this._connections.push(connection);
 
         return connection;
+    }
+
+    _shouldRequeuOnConnectionClose(queueEntry) {
+      if (this.options.maxRequeues === undefined || this.options.maxRequeues < 0) {
+        return true;
+      }
+
+      return queueEntry.requeueAttempts && queueEntry.requeueAttempts < this.options.maxRequeues;
+    }
+
+    _failDeliveryOnConnectionClose(connection) {
+        if (connection.queueEntry && connection.queueEntry.callback) {
+            try {
+              connection.queueEntry.callback(new Error('Reached maximum number of retries after connection was closed'));
+            } catch (E) {
+                this.logger.error(
+                    {
+                        err: E,
+                        tnx: 'callback',
+                        messageId: connection.queueEntry.messageId,
+                        cid: connection.id
+                    },
+                    'Callback error for #%s: %s',
+                    connection.id,
+                    E.message
+                );
+            }
+            connection.queueEntry = false;
+        }
+    };
+
+    _requeueEntryOnConnectionClose(connection) {
+        this.logger.debug(
+            {
+                tnx: 'pool',
+                cid: connection.id,
+                messageId: connection.queueEntry.messageId,
+                action: 'requeue'
+            },
+            'Re-queued message <%s> for #%s',
+            connection.queueEntry.messageId,
+            connection.id
+        );
+        this._queue.unshift(connection.queueEntry);
+        connection.queueEntry = false;
     }
 
     /**

--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const EventEmitter = require('events');
 const PoolResource = require('./pool-resource');
@@ -456,7 +456,7 @@ class SMTPPool extends EventEmitter {
             'Re-queued message <%s> for #%s. Attempt: #%s',
             connection.queueEntry.messageId,
             connection.id,
-            connection.queueEntry.requeueAttempts;
+            connection.queueEntry.requeueAttempts
         );
         this._queue.unshift(connection.queueEntry);
         connection.queueEntry = false;


### PR DESCRIPTION
This PR adds additional configuration option `maxRequeues` for SMTPPool to control the number or requeues, when SMTP connections closes unexpectedly. 

If `maxRequeues` is not specified, current behaviour is preserver. 

More details in #1105 