### PR TITLE
Add `options.forceAuth` for SMTP

### DIFF
--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -613,7 +613,7 @@ class SMTPPool extends EventEmitter {
                     return;
                 }
 
-                if (auth && connection.allowsAuth) {
+                if (auth && (connection.allowsAuth || options.forceAuth)) {
                     connection.login(auth, err => {
                         if (returned) {
                             return;

--- a/lib/smtp-pool/pool-resource.js
+++ b/lib/smtp-pool/pool-resource.js
@@ -137,7 +137,7 @@ class PoolResource extends EventEmitter {
                     return;
                 }
 
-                if (this.auth && this.connection.allowsAuth) {
+                if (this.auth && (this.connection.allowsAuth || options.forceAuth)) {
                     this.connection.login(this.auth, err => {
                         if (returned) {
                             return;

--- a/lib/smtp-transport/index.js
+++ b/lib/smtp-transport/index.js
@@ -267,7 +267,7 @@ class SMTPTransport extends EventEmitter {
 
                 let auth = this.getAuth(mail.data.auth);
 
-                if (auth && connection.allowsAuth) {
+                if (auth && (connection.allowsAuth || options.forceAuth)) {
                     connection.login(auth, err => {
                         if (auth && auth !== this.auth && auth.oauth2) {
                             auth.oauth2.removeAllListeners();
@@ -370,7 +370,7 @@ class SMTPTransport extends EventEmitter {
 
                 let authData = this.getAuth({});
 
-                if (authData && connection.allowsAuth) {
+                if (authData && (connection.allowsAuth || options.forceAuth)) {
                     connection.login(authData, err => {
                         if (returned) {
                             return;

--- a/test/smtp-transport/smtp-tranport-test.js
+++ b/test/smtp-transport/smtp-tranport-test.js
@@ -179,6 +179,34 @@ describe('SMTP Transport Tests', function() {
             );
         });
 
+        it('Should fail auth if forceAuth=true', function(done) {
+            let client = new SMTPTransport({
+                port: PORT_NUMBER,
+                auth: {
+                    user: 'zzz'
+                },
+                forceAuth: true,
+                logger: false
+            });
+
+            client.send(
+                {
+                    data: {},
+                    message: new MockBuilder(
+                        {
+                            from: 'test@valid.sender',
+                            to: 'test@valid.recipient'
+                        },
+                        'message'
+                    )
+                },
+                function(err) {
+                    expect(err.code).to.equal('EAUTH');
+                    done();
+                }
+            );
+        });
+
         it('Should send mail', function(done) {
             let client = new SMTPTransport('smtp:localhost:' + PORT_NUMBER + '?logger=false');
             let chunks = [],


### PR DESCRIPTION
## Context

This PR is in response to the change implemented in v6.4.0, discussed at https://github.com/nodemailer/nodemailer/issues/1081, and changed in https://github.com/nodemailer/nodemailer/commit/f419b09de7a8fe445439a99b450afa9aee1a8a5f.

We have an SMTP integration that is configurable by our end-users. The end-user is able to provide an SMTP server and necessary credentials. If our user provides credentials, we think our user expects us to use them. The behavior introduced in #1081 makes this assumption false. Our user could be saving some invalid credentials, but emails go through nonetheless because our nodemailer integration would not even use them, if the remote server does not advertise `AUTH` support.

For our users that which to use their SMTP server anonymously (with no credentials), we would encourage to make it explicit, by asking them to omit the credentials in the configuration, so that it is in-line with their expectations.

## Changes

This PR re-introduces the behavior that was changed in f419b09de7a8fe445439a99b450afa9aee1a8a5f, but only behind a new `options.forceAuth` boolean option, that defaults to `false`.

Library users that want to go back to the old behavior can pass this option when creating the SMTP transport:
```
nodemailer.createTransport({
  host: "smtp.example.com",
  port: 587,
  auth: {
    user: "username",
    pass: "password"
  },
  forceAuth: true //new!
});
```
Note that `forceAuth` is only useful when an `auth` attribute was provided. The option is ignored in other cases.

---

Please let me know if we should iterate on this change, and whether this can be valuable to other library users.