### PR TITLE
fix: `requeueAttempts=n` should requeue `n` times

### DIFF
--- a/lib/smtp-pool/index.js
+++ b/lib/smtp-pool/index.js
@@ -420,7 +420,7 @@ class SMTPPool extends EventEmitter {
             return true;
         }
 
-        return queueEntry.requeueAttempts && queueEntry.requeueAttempts < this.options.maxRequeues;
+        return queueEntry.requeueAttempts < this.options.maxRequeues;
     }
 
     _failDeliveryOnConnectionClose(connection) {


### PR DESCRIPTION
The initial value of `queueEntry.requeueAttempts` is `0`, which is falsy and breaks the requeuing condition. We can just remove that condition because `queueEntry.requeueAttempts` is guaranteed to be defined.

This PR fixes the new logic introduced in https://github.com/nodemailer/nodemailer/pull/1106.