### PR TITLE
More expressive oath2 error response

### DIFF
--- a/lib/xoauth2/index.js
+++ b/lib/xoauth2/index.js
@@ -261,7 +261,15 @@ class XOAuth2 extends Stream {
             );
 
             if (data.error) {
-                return callback(new Error(data.error));
+                // Error Response : https://tools.ietf.org/html/rfc6749#section-5.2
+                let errorMessage = data.error;
+                if(data.error_description) {
+                  errorMessage += ': ' + data.error_description;
+                }
+                if(data.error_uri) {
+                  errorMessage += ' (' + data.error_uri + ')';
+                }
+                return callback(new Error(errorMessage));
             }
 
             if (data.access_token) {


### PR DESCRIPTION
This just changes the error message for the getToken calll to include all of the possible returned fields (if set) as defined in the spec. Particularly useful for debugging an emergent issue - would have saved us some time this morning :smile: