### PR TITLE
Added OhMySMTP to services

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -148,6 +148,12 @@
         "secure": false
     },
 
+    "OhMySMTP": {
+        "host": "smtp.ohmysmtp.com",
+        "port": 587,
+        "secure": false
+    },
+
     "Postmark": {
         "aliases": ["PostmarkApp"],
         "host": "smtp.postmarkapp.com",


### PR DESCRIPTION
https://ohmysmtp.com is a new transactional email provider, this commit adds their SMTP server details to the well-known services.