### PR TITLE
Fixes resolveContent with streams overriding data

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -327,7 +327,11 @@ module.exports.resolveContent = (data, key, callback) => {
                 }
                 // we can't stream twice the same content, so we need
                 // to replace the stream object with the streaming result
-                data[key] = value;
+                if (data[key].content) {
+                    data[key].content = value;
+                } else {
+                    data[key] = value;
+                }
                 callback(null, value);
             });
         } else if (/^https?:\/\//i.test(content.path || content.href)) {

--- a/test/shared/shared-test.js
+++ b/test/shared/shared-test.js
@@ -200,6 +200,30 @@ describe('Shared Funcs Tests', function () {
             });
         });
 
+        it('should set content from a stream and preserve other properties', function (done) {
+            let mail = {
+                data: {
+                    attachment: {
+                        filename: 'message.html',
+                        content: fs.createReadStream(__dirname + '/fixtures/message.html')
+                    }
+                }
+            };
+            shared.resolveContent(mail.data, 'attachment', function (err, value) {
+                expect(err).to.not.exist;
+                expect(mail).to.deep.equal({
+                    data: {
+                        attachment: {
+                            filename: 'message.html',
+                            content: Buffer.from('<p>Tere, tere</p><p>vana kere!</p>\n')
+                        }
+                    }
+                });
+                expect(value).to.deep.equal(Buffer.from('<p>Tere, tere</p><p>vana kere!</p>\n'));
+                done();
+            });
+        });
+
         it('should return an error', function (done) {
             let mail = {
                 data: {


### PR DESCRIPTION
Hello,

When resolveContent is used with the content property passed as a stream, all the other properties on the object get lost when the stream is replaced with the result.

In my case, the stream was used for an attachment. The attachement object had both filename and content properties set. But sending the email using nodemailer-sendgrid would fail because the attachment filename would be missing.