### PR TITLE
Bugfix/c woople 1294 transport throws error when calling transporter.verify

### DIFF
--- a/lib/ses-transport/index.js
+++ b/lib/ses-transport/index.js
@@ -315,13 +315,22 @@ class SESTransport extends EventEmitter {
         const sesMessage = {
             RawMessage: {
                 // required
-                Data: 'From: invalid@invalid\r\nTo: invalid@invalid\r\n Subject: Invalid\r\n\r\nInvalid'
+                /**
+                 *  aws-sdk/client-ses "SendRawEmailCommand" expects "Data" to be a Buffer array
+                 *  Previously the "Data" property was a string causing it to throw an error "cannot read property 'bytelength' of undefined"
+                 *  See @aws-sdk/util-base64-node/dist/cjs/index.js
+                 */
+                Data: Buffer.from('From: invalid@invalid\r\nTo: invalid@invalid\r\n Subject: Invalid\r\n\r\nInvalid')
             },
             Source: 'invalid@invalid',
             Destinations: ['invalid@invalid']
         };
         const cb = err => {
-            if (err && err.code !== 'InvalidParameterValue') {
+            /**
+             *  Old conditional was accessing a undefined property "err.code"
+             *  It should be looking at "err.Code"
+             */
+            if (err && err.Code !== 'InvalidParameterValue') {
                 return callback(err);
             }
             return callback(null, true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodemailer",
-    "version": "6.6.1",
+    "version": "6.6.1-rc1294",
     "description": "Easy as cake e-mail sending from your Node.js applications",
     "main": "lib/nodemailer.js",
     "scripts": {


### PR DESCRIPTION
fixes #1294 

Line 323: Assigns a buffer object to sesMessage.RawMessage.Data using Buffer.from() passing in the original string value that was there. Prior to this change it was causing the error "Cannot read property 'byteLength' of undefined" thrown by the underlying @aws-sdk/client-ses package. 

Line 333: This conditional was originally trying to access "err.code" which was returning undefined. Changed it to look at err.Code. Prior to this change, it was causing the callback to return an error even when the returned code was "InvalidParameterValue".

Ran the grunt test script after making the changes.