### PR TITLE
Bug Fix: SMTPConnection _upgradeConnection method crashes the process

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -873,16 +873,21 @@ class SMTPConnection extends EventEmitter {
         });
 
         this.upgrading = true;
-        this._socket = tls.connect(opts, () => {
-            this.secure = true;
-            this.upgrading = false;
-            this._socket.on('data', this._onSocketData);
+        // tls.connect is not an asynchronous function however it may still throw errors and requires to be wrapped with try/catch
+        try {
+            this._socket = tls.connect(opts, () => {
+                this.secure = true;
+                this.upgrading = false;
+                this._socket.on('data', this._onSocketData);
 
-            socketPlain.removeListener('close', this._onSocketClose);
-            socketPlain.removeListener('end', this._onSocketEnd);
+                socketPlain.removeListener('close', this._onSocketClose);
+                socketPlain.removeListener('end', this._onSocketEnd);
 
-            return callback(null, true);
-        });
+                return callback(null, true);
+            });
+        } catch (err) {
+            return callback(err);
+        }
 
         this._socket.on('error', this._onSocketError);
         this._socket.once('close', this._onSocketClose);


### PR DESCRIPTION
In smtpConnection the method _upgradeConnection calls tls.connect, tls.connect return a socket which event driven, however before tls.connect returns a socket upon which we add event handlers (i.e. on 'error' etc...) the connect method it self may throw an error, this error is not handled in the code and causes the process to crash due to the fact it can't be caught.


