### PR TITLE
Export parseConnectionUrl from main module.

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -141,3 +141,5 @@ module.exports.getTestMessageUrl = function (info) {
 
     return false;
 };
+
+module.exports.parseConnectionUrl = shared.parseConnectionUrl

--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -142,4 +142,4 @@ module.exports.getTestMessageUrl = function (info) {
     return false;
 };
 
-module.exports.parseConnectionUrl = shared.parseConnectionUrl
+module.exports.parseConnectionUrl = shared.parseConnectionUrl;


### PR DESCRIPTION
It would be useful to be able to parse urls for `nodemailer.createTransport` configuration from other modules. One use case of this is preparing a connection configuration for Google Workspace, which requires setting the "name" parameter to the proper domain. https://github.com/RocketChat/Rocket.Chat/issues/11846#issuecomment-890418288
