### PR TITLE
resolver: skip answers of unsupported IP versions

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -8,10 +8,21 @@ const fs = require('fs');
 const fetch = require('../fetch');
 const dns = require('dns');
 const net = require('net');
+const os = require('os');
 
 const DNS_TTL = 5 * 60 * 1000;
 
 const resolver = (family, hostname, callback) => {
+    const familySupported = Object.values(os.networkInterfaces()).
+        flat().
+        filter(i => !i.internal).
+        filter(i => i.family === 'IPv' + family).
+        length > 0;
+
+    if (!familySupported) {
+        return callback(null, []);
+    }
+
     dns['resolve' + family](hostname, (err, addresses) => {
         if (err) {
             switch (err.code) {


### PR DESCRIPTION
The previous code always started checking for an A record, falling back
to an AAAA if the first does not exists. Since most domains have an A
record - and if only for compatibility reasons - this one is also
returned on machines which do not even have an IPv4 connection,
resulting in connectivity issues.

This change will also take a look at the current machine's network
interfaces and only return A records if a local IPv4 address exists,
same for AAAA records and local IPv6 addresses.

This closes #1310.