### PR TITLE
Fix ses verify for sdk v3

### DIFF
--- a/lib/ses-transport/index.js
+++ b/lib/ses-transport/index.js
@@ -321,7 +321,7 @@ class SESTransport extends EventEmitter {
             Destinations: ['invalid@invalid']
         };
         const cb = err => {
-            if (err && err.code !== 'InvalidParameterValue') {
+            if (err && (err.code || err.Code) !== 'InvalidParameterValue') {
                 return callback(err);
             }
             return callback(null, true);
@@ -335,6 +335,7 @@ class SESTransport extends EventEmitter {
 
         if (typeof ses.send === 'function' && aws.SendRawEmailCommand) {
             // v3 API
+            sesMessage.RawMessage.Data = Buffer.from(sesMessage.RawMessage.Data);
             ses.send(new aws.SendRawEmailCommand(sesMessage), cb);
         } else {
             // v2 API


### PR DESCRIPTION
### Fixed

- When using SES SDK v3, the error object has a err.Code, instead of err.code
- When using SES SDK v3, the Data of a RawMessage needs to be a Buffer. See https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-ses/modules/rawmessage.html

---
Basically the same as https://github.com/nodemailer/nodemailer/pull/1295
closes https://github.com/nodemailer/nodemailer/issues/1294