### PR TITLE
Fix typo in qp/index.js

### DIFF
--- a/lib/qp/index.js
+++ b/lib/qp/index.js
@@ -149,7 +149,7 @@ function checkRanges(nr, ranges) {
  *
  * @constructor
  * @param {Object} options Stream options
- * @param {Number} [options.lineLength=76] Maximum lenght for lines, set to false to disable wrapping
+ * @param {Number} [options.lineLength=76] Maximum length for lines, set to false to disable wrapping
  */
 class Encoder extends Transform {
     constructor(options) {


### PR DESCRIPTION
lenght -> length

NB! Nodemailer is frozen, so no new features please, only bug fixes.
