### PR TITLE
fix: DSN recipient gets ignored

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -1108,7 +1108,7 @@ class SMTPConnection extends EventEmitter {
             notify = notify.join(',');
         }
 
-        let orcpt = (params.orcpt || params.recipient || '').toString() || null;
+        let orcpt = (params.recipient || params.orcpt || '').toString() || null;
         if (orcpt && orcpt.indexOf(';') < 0) {
             orcpt = 'rfc822;' + orcpt;
         }


### PR DESCRIPTION
NB! Nodemailer is frozen, so no new features please, only bug fixes.

As reported in #1374 I fixed this problem by simply swapping these two parameters, like reported in another issues 2 years ago.