### PR TITLE
Update SendCloud service config

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -188,8 +188,8 @@
     },
 
     "SendCloud": {
-        "host": "smtpcloud.sohu.com",
-        "port": 25
+        "host": "smtp.sendcloud.net",
+        "port": 2525
     },
 
     "SendGrid": {


### PR DESCRIPTION
- Domain smtpcloud.sohu.com is deprecated.
- Use 2525 port to avoid a port ban
