### PR TITLE
Fix typo in base64/index.js

### DIFF
--- a/lib/base64/index.js
+++ b/lib/base64/index.js
@@ -51,7 +51,7 @@ function wrap(str, lineLength) {
  *
  * @constructor
  * @param {Object} options Stream options
- * @param {Number} [options.lineLength=76] Maximum lenght for lines, set to false to disable wrapping
+ * @param {Number} [options.lineLength=76] Maximum length for lines, set to false to disable wrapping
  */
 class Encoder extends Transform {
     constructor(options) {


### PR DESCRIPTION
lenght -> length

