### PR TITLE
add dns.REFUSED

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -56,6 +56,7 @@ const resolver = (family, hostname, options, callback) => {
                 case dns.NOTIMP:
                 case dns.SERVFAIL:
                 case dns.CONNREFUSED:
+                case dns.REFUSED:
                 case 'EAI_AGAIN':
                     return callback(null, []);
             }


### PR DESCRIPTION
When a local DNS server does not allow recursion, it can return the error "Query Refused" as told in `**RFC1035 Section 4.1.1 RCODE 5**: Refused - The name server refuses to perform the specified operation for policy reasons.  For example, a name server may not wish toprovide the information to the particular requester, or a name server may not wish to perform a particular operation (e.g., zone transfer) for particular data.` So this is another case which the request shoud go to the next resolver.

NB! Nodemailer is frozen, so no new features please, only bug fixes.
