### PR TITLE
Add DNS timeout

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -48,7 +48,7 @@ const resolver = (family, hostname, options, callback) => {
         return callback(null, []);
     }
 
-    const resolver = dns.Resolver ? new dns.Resolver(options) : dns
+    const resolver = dns.Resolver ? new dns.Resolver(options) : dns;
     resolver['resolve' + family](hostname, (err, addresses) => {
         if (err) {
             switch (err.code) {

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -48,7 +48,8 @@ const resolver = (family, hostname, options, callback) => {
         return callback(null, []);
     }
 
-    dns['resolve' + family](hostname, (err, addresses) => {
+    const resolver = new dns.Resolver(options)
+    resolver['resolve' + family](hostname, (err, addresses) => {
         if (err) {
             switch (err.code) {
                 case dns.NODATA:

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -48,7 +48,7 @@ const resolver = (family, hostname, options, callback) => {
         return callback(null, []);
     }
 
-    const resolver = new dns.Resolver(options)
+    const resolver = dns.Resolver ? new dns.Resolver(options) : dns
     resolver['resolve' + family](hostname, (err, addresses) => {
         if (err) {
             switch (err.code) {

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -14,6 +14,7 @@ const shared = require('../shared');
 const CONNECTION_TIMEOUT = 2 * 60 * 1000; // how much to wait for the connection to be established
 const SOCKET_TIMEOUT = 10 * 60 * 1000; // how much to wait for socket inactivity before disconnecting the client
 const GREETING_TIMEOUT = 30 * 1000; // how much to wait after connection is established but SMTP greeting is not receieved
+const DNS_TIMEOUT = 30 * 1000; // how much to wait for resolveHostname 
 
 /**
  * Generates a SMTP connection object
@@ -30,6 +31,7 @@ const GREETING_TIMEOUT = 30 * 1000; // how much to wait after connection is esta
  *  * **greetingTimeout** - Time to wait in ms until greeting message is received from the server (defaults to 10000)
  *  * **connectionTimeout** - how many milliseconds to wait for the connection to establish
  *  * **socketTimeout** - Time of inactivity until the connection is closed (defaults to 1 hour)
+ *  * **dnsTimeout** - Time to wait in ms for the DNS requests to be resolved (defaults to 30 seconds)
  *  * **lmtp** - if true, uses LMTP instead of SMTP protocol
  *  * **logger** - bunyan compatible logger interface
  *  * **debug** - if true pass SMTP traffic to the logger
@@ -220,7 +222,8 @@ class SMTPConnection extends EventEmitter {
         let opts = {
             port: this.port,
             host: this.host,
-            allowInternalNetworkInterfaces: this.allowInternalNetworkInterfaces
+            allowInternalNetworkInterfaces: this.allowInternalNetworkInterfaces,
+            timeout: this.options.dnsTimeout || DNS_TIMEOUT
         };
 
         if (this.options.localAddress) {


### PR DESCRIPTION
When DNS server does not respond, nodemailer timeouts only after 150 seconds on Mac OS X

```
dev Request --> POST /api/preview

Error: queryA ETIMEOUT smtp.sendgrid.net at QueryReqWrap.onresolve [as oncomplete] (node:dns:279:19) {
 (node:dns:279:19) {
  errno: undefined,
  code: 'EDNS',
  syscall: 'queryA',
  hostname: 'smtp.sendgrid.net',
  command: 'CONN'
}

dev Response <-- 500 POST /api/preview Δ 151071ms
```

This change adds `dnsTimeout` which is passed to dns [1] NodeJS module.

- 1: https://nodejs.org/api/dns.html#resolveroptions