### PR TITLE
fix sendMail function: callback should be optional

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -137,7 +137,7 @@ class Mail extends EventEmitter {
      * @param {Object} data E-data description
      * @param {Function?} callback Callback to run once the sending succeeded or failed
      */
-    sendMail(data, callback) {
+    sendMail(data, callback = null) {
         let promise;
 
         if (!callback) {


### PR DESCRIPTION
This is a bug fix.

The JS Doc above the sendMail function shows "callback?" (meaning it was meant to be optional) and has logic to create a default callback if none is provided. However, the method header does not actually provide the callback argument a default value (null).

This minor fix is important for TypeScript users, because it will correctly inform the static type checker aware that this argument is optional.