### PR TITLE
feat: added https://forwardemail.net to well-known services

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -42,6 +42,14 @@
         "secure": true
     },
 
+    "Forward Email": {
+        "aliases": ["FE", "ForwardEmail"],
+        "domains": ["forwardemail.net"],
+        "host": "smtp.forwardemail.net",
+        "port": 465,
+        "secure": true
+    },
+
     "GandiMail": {
         "aliases": ["Gandi", "Gandi Mail"],
         "host": "mail.gandi.net",


### PR DESCRIPTION
NB! Nodemailer is frozen, so no new features please, only bug fixes.
