### PR TITLE
add SMTP endpoints for the AP region (SES)

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -254,6 +254,42 @@
         "secure": true
     },
 
+    "SES-AP-SOUTH-1": {
+        "host": "email-smtp.ap-south-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "SES-AP-NORTHEAST-1": {
+        "host": "email-smtp.ap-northeast-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "SES-AP-NORTHEAST-2": {
+        "host": "email-smtp.ap-northeast-2.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "SES-AP-NORTHEAST-3": {
+        "host": "email-smtp.ap-northeast-3.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "SES-AP-SOUTHEAST-1": {
+        "host": "email-smtp.ap-southeast-1.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "SES-AP-SOUTHEAST-2": {
+        "host": "email-smtp.ap-southeast-2.amazonaws.com",
+        "port": 465,
+        "secure": true
+    },
+
     "Sparkpost": {
         "aliases": ["SparkPost", "SparkPost Mail"],
         "domains": ["sparkpost.com"],


### PR DESCRIPTION
Submitting this PR to add SES SMTP endpoints for the Asia Pacific region. 
You can find the complete list of SMTP endpoints in this [link](https://docs.aws.amazon.com/general/latest/gr/ses.html).
