### PR TITLE
chore: add mailcatch.app to well-known/services.json

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -120,6 +120,11 @@
         "secure": true
     },
 
+    "Mailcatch.app": {
+        "host": "sandbox-smtp.mailcatch.app",
+        "port": 2525
+    },
+
     "Maildev": {
         "port": 1025,
         "ignoreTLS": true


### PR DESCRIPTION
I am adding the mailcatch.app service to the well-known/services.json file. 
Mailcatch.app is a service commonly used for email testing and debugging purposes. 

Thank you!