### PR TITLE
Update services.json

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -107,7 +107,7 @@
     "Infomaniak": {
         "host": "mail.infomaniak.com",
         "domains": ["ik.me", "ikmail.com", "etik.com"],
-        "port": 587
+        "port": 465
     },
 
     "mail.ee": {


### PR DESCRIPTION
Infomaniak port is better to be 465 than 587

Proof : https://arc.net/l/quote/bigxdsaf

NB! Nodemailer is frozen, so no new features please, only bug fixes.
