### PR TITLE
Update Mailtrap host and port in well known

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -155,8 +155,8 @@
     },
 
     "Mailtrap": {
-        "host": "smtp.mailtrap.io",
-        "port": 2525
+        "host": "live.smtp.mailtrap.io",
+        "port": 587
     },
 
     "Mandrill": {


### PR DESCRIPTION
Hi Nodemailer team.

This PR Updates the Mailtrap service `host` and `port` in well-known/services.