### PR TITLE
chore(services): add seznam.cz

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -306,6 +306,14 @@
         "secure": true
     },
 
+    "Seznam": {
+        "aliases": ["Seznam Email"],
+        "domains": ["seznam.cz", "email.cz", "post.cz", "spoluzaci.cz"],
+        "host": "smtp.seznam.cz",
+        "port": 465,
+        "secure": true
+    },
+
     "Sparkpost": {
         "aliases": ["SparkPost", "SparkPost Mail"],
         "domains": ["sparkpost.com"],


### PR DESCRIPTION
This PR adds configuration for the Seznam email service to the well-known services list.