### PR TITLE
fix: prevent ECONNRESET by adding error handler to socket

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -364,6 +364,11 @@ class Mail extends EventEmitter {
                             if (err) {
                                 return callback(err);
                             }
+                            if (info.socket) {
+                                info.socket.on('error', (err) => {
+                                    // Catch the uncatchable ECONNRESET and ignore it
+                                })
+                            }
                             return callback(null, {
                                 connection: info.socket || info
                             });


### PR DESCRIPTION
We had this bug in our production system for months. Some rare networking issue randomly causes an ECONNRESET and it was not reproducible under development conditions. I made it my mission to find the cause, and after a lot of trial and error (because Node runtime makes it almost impossible to easily debug) we zeroed in on the nodemailer package. In modern node versions the uncaught ECONNRESET crashes the process or leaves the process in an unknown state, so it was a real pain for us.  We found that doing this fixed 100% of server crashes and no more ECONNRESET issues, so thought I'd share.