### PR TITLE
readme: add syntax highlighting to code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It's either a firewall issue, or your SMTP server blocks authentication attempts
 -   You might have the wrong value for the `secure` option. This should be set to `true` only for port 465. For every other port, it should be `false`. Setting it to `false` does not mean that Nodemailer would not use TLS. Nodemailer would still try to upgrade the connection to use TLS if the server supports it.
 -   Older Node versions do not fully support the certificate chain of the newest Let's Encrypt certificates. Either set [tls.rejectUnauthorized](https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#tlsconnectoptions-callback) to `false` to skip chain verification or upgrade your Node version
 
-```
+```js
 let configOptions = {
     host: "smtp.example.com",
     port: 587,
@@ -57,7 +57,7 @@ let configOptions = {
 
 Node.js uses [c-ares](https://nodejs.org/en/docs/meta/topics/dependencies/#c-ares) to resolve domain names, not the DNS library provided by the system, so if you have some custom DNS routing set up, it might be ignored. Nodemailer runs [dns.resolve4()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve4hostname-options-callback) and [dns.resolve6()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve6hostname-options-callback) to resolve hostname into an IP address. If both calls fail, then Nodemailer will fall back to [dns.lookup()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnslookuphostname-options-callback). If this does not work for you, you can hard code the IP address into the configuration like shown below. In that case, Nodemailer would not perform any DNS lookups.
 
-```
+```js
 let configOptions = {
     host: "1.2.3.4",
     port: 465,


### PR DESCRIPTION
Hey there! Quick fix to the README, so the code blocks use syntax highlighting.