### PR TITLE
smtp-connection: fix jsdoc public annotation for socket

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -124,7 +124,7 @@ class SMTPConnection extends EventEmitter {
 
         /**
          * The socket connecting to the server
-         * @publick
+         * @public
          */
         this._socket = false;
 


### PR DESCRIPTION
Just noticed this JSDoc public annotation typo for the `_socket` in `smtp-connection`
