### PR TITLE
fix(encoder): avoid silent data loss by properly flushing trailing base64

### DIFF
--- a/lib/base64/index.js
+++ b/lib/base64/index.js
@@ -35,15 +35,12 @@ function wrap(str, lineLength) {
     let pos = 0;
     let chunkLength = lineLength * 1024;
     while (pos < str.length) {
-        let wrappedLines = str
-            .substr(pos, chunkLength)
-            .replace(new RegExp('.{' + lineLength + '}', 'g'), '$&\r\n')
-            .trim();
+        let wrappedLines = str.substr(pos, chunkLength).replace(new RegExp('.{' + lineLength + '}', 'g'), '$&\r\n');
         result.push(wrappedLines);
         pos += chunkLength;
     }
 
-    return result.join('\r\n').trim();
+    return result.join('');
 }
 
 /**
@@ -95,23 +92,22 @@ class Encoder extends Transform {
         let b64 = this._curLine + encode(chunk);
 
         if (this.options.lineLength) {
-            // Wrap the base64 string at the configured line length, inserting soft line breaks.
             b64 = wrap(b64, this.options.lineLength);
 
-            // Split the wrapped base64 string into lines by line breaks.
-            const lines = b64.split(/\r?\n/);
-            // The last line may be incomplete (no trailing line break),
-            // so we store it in _curLine for the next chunk or for flushing later.
-            this._curLine = lines.pop() || '';
+            let lastLF = b64.lastIndexOf('\n');
+            if (lastLF < 0) {
+                this._curLine = b64;
+                b64 = '';
+            } else {
+                this._curLine = b64.substring(lastLF + 1);
+                b64 = b64.substring(0, lastLF + 1);
 
-            // Join the complete lines back with CRLF line breaks to push downstream.
-            b64 = lines.join('\r\n');
-
-            // Append a trailing CRLF if there is any data to push,
-            // ensuring that complete lines end properly.
-            if (b64) {
-                b64 += '\r\n';
+                if (b64 && !b64.endsWith('\r\n')) {
+                    b64 += '\r\n';
+                }
             }
+        } else {
+            this._curLine = '';
         }
 
         if (b64) {
@@ -128,9 +124,8 @@ class Encoder extends Transform {
         }
 
         if (this._curLine) {
-            this._curLine = wrap(this._curLine, this.options.lineLength);
             this.outputBytes += this._curLine.length;
-            this.push(this._curLine, 'ascii');
+            this.push(Buffer.from(this._curLine, 'ascii'));
             this._curLine = '';
         }
         done();

--- a/lib/base64/index.js
+++ b/lib/base64/index.js
@@ -56,7 +56,6 @@ function wrap(str, lineLength) {
 class Encoder extends Transform {
     constructor(options) {
         super();
-        // init Transform
         this.options = options || {};
 
         if (this.options.lineLength !== false) {
@@ -96,18 +95,22 @@ class Encoder extends Transform {
         let b64 = this._curLine + encode(chunk);
 
         if (this.options.lineLength) {
+            // Wrap the base64 string at the configured line length, inserting soft line breaks.
             b64 = wrap(b64, this.options.lineLength);
 
-            // remove last line as it is still most probably incomplete
-            let lastLF = b64.lastIndexOf('\n');
-            if (lastLF < 0) {
-                this._curLine = b64;
-                b64 = '';
-            } else if (lastLF === b64.length - 1) {
-                this._curLine = '';
-            } else {
-                this._curLine = b64.substr(lastLF + 1);
-                b64 = b64.substr(0, lastLF + 1);
+            // Split the wrapped base64 string into lines by line breaks.
+            const lines = b64.split(/\r?\n/);
+            // The last line may be incomplete (no trailing line break),
+            // so we store it in _curLine for the next chunk or for flushing later.
+            this._curLine = lines.pop() || '';
+
+            // Join the complete lines back with CRLF line breaks to push downstream.
+            b64 = lines.join('\r\n');
+
+            // Append a trailing CRLF if there is any data to push,
+            // ensuring that complete lines end properly.
+            if (b64) {
+                b64 += '\r\n';
             }
         }
 
@@ -134,7 +137,6 @@ class Encoder extends Transform {
     }
 }
 
-// expose to the world
 module.exports = {
     encode,
     wrap,

--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -43,6 +43,16 @@
         "port": 587
     },
 
+    "Aruba": {
+        "description": "Aruba PEC (Italian email provider)",
+        "domains": ["aruba.it", "pec.aruba.it"],
+        "aliases": ["Aruba PEC"],
+        "host": "smtps.aruba.it",
+        "port": 465,
+        "secure": true,
+        "authMethod": "LOGIN"
+    },
+
     "Bluewin": {
         "description": "Bluewin (Swiss email provider)",
         "host": "smtpauths.bluewin.ch",
@@ -50,10 +60,27 @@
         "port": 465
     },
 
+    "BOL": {
+        "description": "BOL Mail (Brazilian provider)",
+        "domains": ["bol.com.br"],
+        "host": "smtp.bol.com.br",
+        "port": 587,
+        "requireTLS": true
+    },
+
     "DebugMail": {
         "description": "DebugMail (email testing service)",
         "host": "debugmail.io",
         "port": 25
+    },
+
+    "Disroot": {
+        "description": "Disroot (privacy-focused provider)",
+        "domains": ["disroot.org"],
+        "host": "smtp.disroot.org",
+        "port": 587,
+        "secure": true,
+        "authMethod": "LOGIN"
     },
 
     "DynectEmail": {
@@ -171,6 +198,16 @@
         "host": "mail.infomaniak.com",
         "domains": ["ik.me", "ikmail.com", "etik.com"],
         "port": 587
+    },
+
+    "KolabNow": {
+        "description": "KolabNow (secure email service)",
+        "domains": ["kolabnow.com"],
+        "aliases": ["Kolab"],
+        "host": "smtp.kolabnow.com",
+        "port": 465,
+        "secure": true,
+        "authMethod": "LOGIN"
     },
 
     "Loopia": {
@@ -324,6 +361,14 @@
     "Resend": {
         "description": "Resend",
         "host": "smtp.resend.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "Runbox": {
+        "description": "Runbox (Norwegian email provider)",
+        "domains": ["runbox.com"],
+        "host": "smtp.runbox.com",
         "port": 465,
         "secure": true
     },
@@ -546,6 +591,14 @@
         "host": "smtp.yandex.ru",
         "port": 465,
         "secure": true
+    },
+
+    "Zimbra": {
+        "description": "Zimbra Mail Server",
+        "aliases": ["Zimbra Collaboration"],
+        "host": "smtp.zimbra.com",
+        "port": 587,
+        "requireTLS": true
     },
 
     "Zoho": {

--- a/test/base64/base64-test.js
+++ b/test/base64/base64-test.js
@@ -110,5 +110,38 @@ describe('Base64 Tests', () => {
                 done();
             });
         });
+
+        it('should flush incomplete trailing base64 chunks correctly', (t, done) => {
+            const encoder = new base64.Encoder({ lineLength: 10 });
+
+            // Prepare a buffer of 5 bytes, which encodes to 8 base64 characters.
+            // This length is below the specified lineLength (10), so no wrapping should occur.
+            const input = Buffer.from('12345');
+            let output = Buffer.alloc(0);
+
+            encoder.on('data', chunk => {
+                // Accumulate the data chunks emitted by the base64 encoder stream.
+                output = Buffer.concat([output, chunk]);
+            });
+
+            encoder.on('end', () => {
+                const result = output.toString();
+
+                /**
+                 * The string "12345" encoded in base64 is "MTIzNDU=".
+                 * Since the output length (8 characters) is less than the lineLength (10),
+                 * the encoder should not insert any line breaks.
+                 *
+                 * This test verifies that any incomplete trailing base64 data
+                 * held internally in `_curLine` is correctly flushed and emitted
+                 * when the stream ends, preventing silent data loss.
+                 */
+                assert.strictEqual(result, 'MTIzNDU=');
+                done();
+            });
+
+            encoder.write(input);
+            encoder.end(); // triggers the _flush method
+        });
     });
 });


### PR DESCRIPTION
Previously, base64 encoded chunks without line breaks were incorrectly retained in 
the internal buffer (_curLine) without being flushed if the stream ended prematurely 
or the consumer did not explicitly wait for the flush event.

This caused silent data loss, as the incomplete trailing base64 data was never 
emitted downstream.

This fix modifies the encoding logic to immediately push complete base64 lines, 
retaining only the incomplete trailing data in the internal buffer. This guarantees 
that no data is lost even if the stream ends unexpectedly.

Unit tests were added to cover this scenario, verifying that incomplete trailing 
base64 chunks are properly flushed and emitted, ensuring data integrity and 
consistent stream behavior.