### PR TITLE
fix: refresh expired DNS cache on error

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -126,7 +126,11 @@ module.exports.resolveHostname = (options, callback) => {
     resolver(4, options.host, options, (err, addresses) => {
         if (err) {
             if (cached) {
-                // ignore error, use expired value
+                dnsCache.set(options.host, {
+                    value: cached.value,
+                    expires: Date.now() + (options.dnsTtl || DNS_TTL)
+                });
+
                 return callback(
                     null,
                     formatDNSValue(cached.value, {
@@ -160,7 +164,11 @@ module.exports.resolveHostname = (options, callback) => {
         resolver(6, options.host, options, (err, addresses) => {
             if (err) {
                 if (cached) {
-                    // ignore error, use expired value
+                    dnsCache.set(options.host, {
+                        value: cached.value,
+                        expires: Date.now() + (options.dnsTtl || DNS_TTL)
+                    });
+
                     return callback(
                         null,
                         formatDNSValue(cached.value, {
@@ -195,7 +203,11 @@ module.exports.resolveHostname = (options, callback) => {
                 dns.lookup(options.host, { all: true }, (err, addresses) => {
                     if (err) {
                         if (cached) {
-                            // ignore error, use expired value
+                            dnsCache.set(options.host, {
+                                value: cached.value,
+                                expires: Date.now() + (options.dnsTtl || DNS_TTL)
+                            });
+
                             return callback(
                                 null,
                                 formatDNSValue(cached.value, {
@@ -248,7 +260,11 @@ module.exports.resolveHostname = (options, callback) => {
                 });
             } catch (err) {
                 if (cached) {
-                    // ignore error, use expired value
+                    dnsCache.set(options.host, {
+                        value: cached.value,
+                        expires: Date.now() + (options.dnsTtl || DNS_TTL)
+                    });
+
                     return callback(
                         null,
                         formatDNSValue(cached.value, {


### PR DESCRIPTION
When a DNS lookup fails, the code used the expired cache but did not update its lifetime This caused the system to get stuck always tryng the same incorrect address

Now, when we fall back to an expired cache due to an error, we renew its lifetime This prevents repeated attempts with the same broken address and gives time for the DNS to recover

Improves system stability in DNS failure scenarios

NB! Nodemailer is frozen, so no new features please, only bug fixes.
