### PR TITLE
supporting user options for parseConnectionUrl where default options take precedence 

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -31,7 +31,7 @@ module.exports.createTransport = function (transporter, defaults) {
     ) {
         if ((urlConfig = typeof transporter === 'string' ? transporter : transporter.url)) {
             // parse a configuration URL into configuration options
-            options = shared.parseConnectionUrl(urlConfig);
+            options = shared.parseConnectionUrl(urlConfig, typeof transporter === 'object' ? transporter : {});
         } else {
             options = transporter;
         }

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -310,48 +310,50 @@ module.exports.resolveHostname = (options, callback) => {
  * Parses connection url to a structured configuration object
  *
  * @param {String} str Connection url
+ * @param {Object} [options] Additional options to merge (local options take precedence)
  * @return {Object} Configuration object
  */
-module.exports.parseConnectionUrl = str => {
+module.exports.parseConnectionUrl = (str, options) => {
     str = str || '';
-    let options = {};
+    let userOptions = Object.assign({}, options || {});
+    let baseOptions = {};
 
     [urllib.parse(str, true)].forEach(url => {
         let auth;
 
         switch (url.protocol) {
             case 'smtp:':
-                options.secure = false;
+                baseOptions.secure = false;
                 break;
             case 'smtps:':
-                options.secure = true;
+                baseOptions.secure = true;
                 break;
             case 'direct:':
-                options.direct = true;
+                baseOptions.direct = true;
                 break;
         }
 
         if (!isNaN(url.port) && Number(url.port)) {
-            options.port = Number(url.port);
+            baseOptions.port = Number(url.port);
         }
 
         if (url.hostname) {
-            options.host = url.hostname;
+            baseOptions.host = url.hostname;
         }
 
         if (url.auth) {
             auth = url.auth.split(':');
 
-            if (!options.auth) {
-                options.auth = {};
+            if (!baseOptions.auth) {
+                baseOptions.auth = {};
             }
 
-            options.auth.user = auth.shift();
-            options.auth.pass = auth.join(':');
+            baseOptions.auth.user = auth.shift();
+            baseOptions.auth.pass = auth.join(':');
         }
 
         Object.keys(url.query || {}).forEach(key => {
-            let obj = options;
+            let obj = baseOptions;
             let lKey = key;
             let value = url.query[key];
 
@@ -371,22 +373,22 @@ module.exports.parseConnectionUrl = str => {
             // tls is nested object
             if (key.indexOf('tls.') === 0) {
                 lKey = key.substr(4);
-                if (!options.tls) {
-                    options.tls = {};
+                if (!baseOptions.tls) {
+                    baseOptions.tls = {};
                 }
-                obj = options.tls;
+                obj = baseOptions.tls;
             } else if (key.indexOf('.') >= 0) {
                 // ignore nested properties besides tls
                 return;
             }
 
-            if (!(lKey in obj)) {
-                obj[lKey] = value;
-            }
+            // Always set the value, allowing URL params to override user options
+            obj[lKey] = value;
         });
     });
 
-    return options;
+    // Use the custom assign function to properly merge nested objects like tls and auth
+    return module.exports.assign({}, userOptions, baseOptions);
 };
 
 module.exports._logFunc = (logger, level, defaults, data, message, ...args) => {


### PR DESCRIPTION
Resolving issue 1762.

Problem:
When providing the url transporter option, all other options were ignored because the parsing method "parseConnectionUr!" accepted only url and ignored all others. The "parseConnectionUrl" then proceeded to define its own options and return those.

Solution:
Refactor "parseConnectionUrl" to accept additional transporter options when transporter is an object. When provided with additional transporter options, ensure existing default options (baseOptions) in "parseConnectionUrl" take precedence, then add additional transporter options to be returned in the "parseConnectionUrl" response.