### PR TITLE
chore: correct typo in variable name

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -1147,8 +1147,8 @@ class SMTPConnection extends EventEmitter {
             }
             notify = notify.map(n => n.trim().toUpperCase());
             let validNotify = ['NEVER', 'SUCCESS', 'FAILURE', 'DELAY'];
-            let invaliNotify = notify.filter(n => !validNotify.includes(n));
-            if (invaliNotify.length || (notify.length > 1 && notify.includes('NEVER'))) {
+            let invalidNotify = notify.filter(n => !validNotify.includes(n));
+            if (invalidNotify.length || (notify.length > 1 && notify.includes('NEVER'))) {
                 throw new Error('notify: ' + JSON.stringify(notify.join(',')));
             }
             notify = notify.join(',');


### PR DESCRIPTION
- Corrected variable invaliNotify → invalidNotify 
- No functional changes or behavior impact 
- Improves code clarity and maintainability