### PR TITLE
guard for non-ascii content from being encoded with 7bits

### DIFF
--- a/lib/mail-composer/index.js
+++ b/lib/mail-composer/index.js
@@ -105,7 +105,7 @@ class MailComposer {
             if ('contentTransferEncoding' in attachment) {
                 // also contains `false`, to set
                 contentTransferEncoding = attachment.contentTransferEncoding;
-            } else if (isMessageNode && isAsciiContent) {  //encode safely UTF-8 content
+            } else if (isMessageNode && isAsciiContent) { 
                 contentTransferEncoding = '7bit'; 
             } else {
                 contentTransferEncoding = 'base64'; // the default


### PR DESCRIPTION
We should probably maintain backwards compatibility of encoding for attachments in contrats to v6. It's possible to have a message node with UTF-8 content, which would be encoded with 7 bits leading to loss of information. Here's a suggestion how we could guard against it.