### PR TITLE
Add Gmail Workspace service configuration

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -147,6 +147,14 @@
         "secure": true
     },
 
+    "GmailWorkspace": {
+        "description": "Gmail Workspace",
+        "aliases": ["Google Workspace Mail"],
+        "host": "smtp-relay.gmail.com",
+        "port": 465,
+        "secure": true
+    },
+
     "GMX": {
         "description": "GMX Mail",
         "domains": ["gmx.com", "gmx.net", "gmx.de"],


### PR DESCRIPTION
Google's business email service has a different incoming domain for SMTP services. However, Workspace users can use the smtp.gmail.com server but lose the ability to use a customised ‘from’ field.

Could the Gmail service be added separately to Workspace? https://support.google.com/a/answer/176600?hl=en

NB! Nodemailer is frozen, so no new features please, only bug fixes.
