### PR TITLE
Use only one value from single-value-only headers if array was specified

### DIFF
--- a/lib/mail-composer/index.js
+++ b/lib/mail-composer/index.js
@@ -62,8 +62,8 @@ class MailComposer {
             let key = header.replace(/-(\w)/g, (o, c) => c.toUpperCase());
             if (this.mail[key]) {
                 // If the header only allows a single value and specifies an array, only use the first value
-                // 'Subject' is not included as it is omitted later if specified as an array
-                if (['sender', 'message-id', 'date'].includes(key) && Array.isArray(this.mail[key])) {
+                // 'Message-ID' and 'Subject' is not included as it is omitted later if specified as an array
+                if (['sender', 'date'].includes(key) && Array.isArray(this.mail[key])) {
                     this.message.setHeader(header, this.mail[key][0]);
                 }
 


### PR DESCRIPTION
This PR enforces the use of a single value for the `sender` and `date` parameters by using the first if an array is specified for either.

## Context

While using `nodemailer` I've noticed that the library allows specifying an array of values for the following headers:
`['from', 'sender', 'to', 'cc', 'bcc', 'reply-to', 'in-reply-to', 'references', 'subject', 'message-id', 'date']`

Most of these headers do allow multiple values (e.g. `from`, `to`, `references`), but some do not such as `sender`, ~`subject`~, ~`message-id`~ and `date` (see below why subject and message-id were removed).

Using the RFC 5322 as a baseline, the 4 headers mentioned above can only ever be single values (see quotes from the RFC below):

---
**Sender**
```
If the from
   field contains more than one mailbox specification in the mailbox-
   list, then the sender field, containing the field name "Sender" and a
   single mailbox specification, MUST appear in the message.
```

**Date**
```
  ** clarification on spec language since the spec refers to 'orig-date' as the 'Date' header **
  The origination date field consists of the field name "Date" followed
   by a date-time specification.
   orig-date       =   "Date:" date-time CRLF

  ** the spec implies that 'Date' is only supposed to be a single value timestamp **
  The origination date specifies the date and time at which the creator
   of the message indicated that the message was complete and ready to
   enter the mail delivery system.
```
---
**Notable mentions after testing, kept for context**

**Subject** (N/A)
After doing a quick test, I can see that if the `Subject` is not a string (is for e.g. an array), it is stripped completely from the message, hence I removed it from the exclusion array in my PR to maintain this behaviour.

**Message-ID** (N/A)
Same as 'Subject', removed if not a valid string.

---

## Actual `nodemailer` behaviour when using an array in `date` and `sender`
Example code:
```js
transport.sendMail({
    from: ["addr1@gmail.com", "addr2@gmail.com"],
    sender: ["addr1@gmail.com", "addr2@gmail.com"],
    date: [new Date(Date.now()), new Date(Date.now())],
    to: "someemail@example.org",
    subject: "Hello from Nodemailer",
    text: "This demonstrates the different address formats."
});
```

Streamed raw message to SMTP server:
```
From: addr1@gmail.com, addr2@gmail.com
Sender: addr1@gmail.com, addr2@gmail.com
To: someemail@example.org
Subject: Hello from Nodemailer
Date: Sat Dec 20 2025 14:43:36 GMT+0000 (Greenwich Mean Time),Sat Dec 20
 2025 14:43:36 GMT+0000 (Greenwich Mean Time)
...
```

`Date` of course becomes completely malformed if interpreted as an actual `Date`, and multiple `Sender` values aren't allowed and will fail parsing in some SMTP server implementations.

## Misc
I'm not sure if this was intentional by `nodemailer`, but accidental inclusions of an array for either of these headers will result in a non-compliant message, and this patch is more of a "correctness" patch to prevent clients from accidentally producing invalid email messages by providing an array to either (such as via user input). If this patch is too high-risk then feel free to not implement it (especially since if I understood correctly, the library is in a frozen state, but unsure if this would count as a 'bug fix').

As for the patch itself, obvious things such as testing was done to verify behaviour (correctly only uses the first entry in `date` and `sender`) and ensuring that this patch doesn't affect unrelated headers, or the header values that are not an array, the library outcome for those will remain the same.

Let me know what you guys think.