### PR TITLE
Update @aws-sdk/client-sesv2 to version 3.982.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "homepage": "https://nodemailer.com/",
     "devDependencies": {
-        "@aws-sdk/client-sesv2": "3.975.0",
+        "@aws-sdk/client-sesv2": "3.982.0",
         "bunyan": "1.8.15",
         "c8": "10.1.3",
         "eslint": "9.39.2",


### PR DESCRIPTION
Patches low-priority development dependency vulnerability.

Removes annoying warning from projects downstream about the fast-xml-parser DoS Vulnerability.

https://github.com/advisories/GHSA-37qj-frw5-hhjh

<img width="1202" height="223" alt="image" src="https://github.com/user-attachments/assets/1689ca3f-bbf2-4fbe-b445-182f2d3099bd" />