### PR TITLE
Fix/base64 wrap trailing crlf

### DIFF
--- a/test/base64/base64-test.js
+++ b/test/base64/base64-test.js
@@ -50,6 +50,25 @@ describe('Base64 Tests', () => {
             assert.strictEqual(wrapped, 'A'.repeat(76) + '\r\n' + 'A'.repeat(76));
             assert.ok(!wrapped.endsWith('\r\n'));
         });
+
+        it('should preserve content and never emit trailing whitespace across single- and cross-chunk inputs', () => {
+            // lineLength=8 -> chunkLength = 8 * 1024 = 8192. Sweep covers:
+            // sub-lineLength, single-chunk exact/non-exact, single-chunk boundary,
+            // cross-chunk boundary, and 2x-cross-chunk exact-multiple.
+            const lineLength = 8;
+            const sizes = [1, 7, 8, 9, 15, 16, 17, 8191, 8192, 8193, 16383, 16384, 16385];
+
+            sizes.forEach(n => {
+                const input = 'A'.repeat(n);
+                const wrapped = base64.wrap(input, lineLength);
+
+                assert.ok(!/[\r\n]$/.test(wrapped), `size ${n}: output ends in CR/LF`);
+                assert.strictEqual(wrapped.split('\r\n').join(''), input, `size ${n}: content not preserved`);
+                wrapped.split('\r\n').forEach(line => {
+                    assert.ok(line.length <= lineLength, `size ${n}: line ${line.length} > ${lineLength}`);
+                });
+            });
+        });
     });
 
     describe('base64 Streams', () => {
@@ -159,6 +178,30 @@ describe('Base64 Tests', () => {
             });
 
             encoder.end(input);
+        });
+
+        it('should not emit a trailing CRLF when two writes combine to an exact multiple of lineLength', (t, done) => {
+            // After write 1: encode(57 bytes)=76 b64 chars, all stashed in _curLine, nothing pushed.
+            // After write 2: _curLine + encode(57)=152 chars (2 * 76) -> exercises the
+            // last-LF split path with a CRLF-terminated wrap result, plus a non-empty _curLine
+            // at flush time.
+            const encoder = new base64.Encoder({ lineLength: 76 });
+            const half = Buffer.alloc(57, 0x61);
+            let output = Buffer.alloc(0);
+
+            encoder.on('data', chunk => {
+                output = Buffer.concat([output, chunk]);
+            });
+
+            encoder.on('end', () => {
+                const result = output.toString();
+                assert.ok(!result.endsWith('\r\n'), 'base64 stream output must not end with CRLF');
+                assert.strictEqual(result, 'YWFh'.repeat(19) + '\r\n' + 'YWFh'.repeat(19));
+                done();
+            });
+
+            encoder.write(half);
+            encoder.end(half);
         });
     });
 });

--- a/test/base64/base64-test.js
+++ b/test/base64/base64-test.js
@@ -48,7 +48,6 @@ describe('Base64 Tests', () => {
         it('should not emit a trailing CRLF when input is an exact multiple of lineLength', () => {
             const wrapped = base64.wrap(exactMultipleBase64, 76);
             assert.strictEqual(wrapped, 'A'.repeat(76) + '\r\n' + 'A'.repeat(76));
-            assert.ok(!wrapped.endsWith('\r\n'));
         });
 
         it('should preserve content and never emit trailing whitespace across single- and cross-chunk inputs', () => {

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -309,6 +309,30 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             });
         });
 
+        it('should not emit a blank line before the internal boundary when an earlier sibling base64 body is an exact multiple of lineLength', (t, done) => {
+            // The previous test covers the terminator boundary path
+            // (lib/mime-node/index.js processChildNode last write). This one
+            // covers the inter-sibling path, which uses a different write:
+            // (childId > 1 ? '\r\n' : '') + '--' + boundary + '\r\n'.
+            let mb = new MimeNode('multipart/mixed');
+            mb.createChild('application/octet-stream').setContent(Buffer.alloc(114, 0x61));
+            mb.createChild('application/octet-stream').setContent(Buffer.from('hello'));
+
+            mb.build((err, msg) => {
+                assert.ok(!err);
+                const text = msg.toString();
+                // Split on the boundary marker; each segment between markers is
+                // (header/body separator) + headers + \r\n\r\n + body + \r\n.
+                // A regression would manifest as a body segment ending with
+                // \r\n\r\n (blank line) instead of \r\n.
+                const segments = text.split('--' + mb.boundary);
+                assert.strictEqual(segments.length, 4, 'expected 4 segments: prologue, child 1, child 2, terminator');
+                assert.ok(segments[1].endsWith('\r\n') && !segments[1].endsWith('\r\n\r\n'), 'body of first child must end with exactly one CRLF before the next boundary');
+                assert.ok(segments[2].endsWith('\r\n') && !segments[2].endsWith('\r\n\r\n'), 'body of second child must end with exactly one CRLF before the terminator');
+                done();
+            });
+        });
+
         it('should build root with generated headers', (t, done) => {
             let mb = new MimeNode('text/plain');
             mb.hostname = 'abc';

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -310,22 +310,13 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
         });
 
         it('should not emit a blank line before the internal boundary when an earlier sibling base64 body is an exact multiple of lineLength', (t, done) => {
-            // The previous test covers the terminator boundary path
-            // (lib/mime-node/index.js processChildNode last write). This one
-            // covers the inter-sibling path, which uses a different write:
-            // (childId > 1 ? '\r\n' : '') + '--' + boundary + '\r\n'.
             let mb = new MimeNode('multipart/mixed');
             mb.createChild('application/octet-stream').setContent(Buffer.alloc(114, 0x61));
             mb.createChild('application/octet-stream').setContent(Buffer.from('hello'));
 
             mb.build((err, msg) => {
                 assert.ok(!err);
-                const text = msg.toString();
-                // Split on the boundary marker; each segment between markers is
-                // (header/body separator) + headers + \r\n\r\n + body + \r\n.
-                // A regression would manifest as a body segment ending with
-                // \r\n\r\n (blank line) instead of \r\n.
-                const segments = text.split('--' + mb.boundary);
+                const segments = msg.toString().split('--' + mb.boundary);
                 assert.strictEqual(segments.length, 4, 'expected 4 segments: prologue, child 1, child 2, terminator');
                 assert.ok(segments[1].endsWith('\r\n') && !segments[1].endsWith('\r\n\r\n'), 'body of first child must end with exactly one CRLF before the next boundary');
                 assert.ok(segments[2].endsWith('\r\n') && !segments[2].endsWith('\r\n\r\n'), 'body of second child must end with exactly one CRLF before the terminator');


### PR DESCRIPTION
NB! Nodemailer is frozen, so no new features please, only bug fixes.
