### PR TITLE
fix: keep domain as UTF-8 when local part is non-ASCII

### DIFF
--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -1225,17 +1225,21 @@ class MimeNode {
         let user = address.substr(0, lastAt);
         const domain = address.substr(lastAt + 1);
 
-        // Usernames are not touched and are kept as is even if these include unicode
-        // Domains are punycoded by default
-        // 'jõgeva.ee' will be converted to 'xn--jgeva-dua.ee'
-        // non-unicode domains are left as is
+        // Usernames are not touched and are kept as is even if these include unicode.
+        // Domains are punycoded when the local part is ASCII ('safe@jõgeva.ee' -> 'safe@xn--jgeva-dua.ee').
+        // When the local part contains non-ASCII bytes the address already requires SMTPUTF8,
+        // so the domain is kept (or decoded back) as UTF-8 for symmetry on both sides of '@'.
 
-        let encodedDomain;
+        let encodedDomain = domain;
 
         try {
-            encodedDomain = punycode.toASCII(domain.toLowerCase());
+            if (/[\x80-\uFFFF]/.test(user)) {
+                encodedDomain = punycode.toUnicode(domain.toLowerCase());
+            } else {
+                encodedDomain = punycode.toASCII(domain.toLowerCase());
+            }
         } catch (_err) {
-            // keep as is?
+            // keep domain as supplied
         }
 
         if (user.indexOf(' ') >= 0) {

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -318,8 +318,14 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
                 assert.ok(!err);
                 const segments = msg.toString().split('--' + mb.boundary);
                 assert.strictEqual(segments.length, 4, 'expected 4 segments: prologue, child 1, child 2, terminator');
-                assert.ok(segments[1].endsWith('\r\n') && !segments[1].endsWith('\r\n\r\n'), 'body of first child must end with exactly one CRLF before the next boundary');
-                assert.ok(segments[2].endsWith('\r\n') && !segments[2].endsWith('\r\n\r\n'), 'body of second child must end with exactly one CRLF before the terminator');
+                assert.ok(
+                    segments[1].endsWith('\r\n') && !segments[1].endsWith('\r\n\r\n'),
+                    'body of first child must end with exactly one CRLF before the next boundary'
+                );
+                assert.ok(
+                    segments[2].endsWith('\r\n') && !segments[2].endsWith('\r\n\r\n'),
+                    'body of second child must end with exactly one CRLF before the terminator'
+                );
                 done();
             });
         });
@@ -929,6 +935,36 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
                 }
             );
         });
+
+        it('should keep envelope domains as UTF-8 when local part is non-ASCII', () => {
+            assert.deepStrictEqual(
+                new MimeNode()
+                    .setHeader({
+                        from: { name: 'Jõser', address: 'jõser@jõgeva.ee' },
+                        to: { name: 'Jõser', address: 'jõser@jõgeva.ee' }
+                    })
+                    .getEnvelope(),
+                {
+                    from: 'jõser@jõgeva.ee',
+                    to: ['jõser@jõgeva.ee']
+                }
+            );
+        });
+
+        it('should normalize a punycoded envelope back to UTF-8 when local part is non-ASCII', () => {
+            assert.deepStrictEqual(
+                new MimeNode()
+                    .setEnvelope({
+                        from: 'jõser@xn--jgeva-dua.ee',
+                        to: ['jõser@xn--jgeva-dua.ee']
+                    })
+                    .getEnvelope(),
+                {
+                    from: 'jõser@jõgeva.ee',
+                    to: ['jõser@jõgeva.ee']
+                }
+            );
+        });
     });
 
     describe('#messageId', () => {
@@ -1206,6 +1242,17 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
                 'the safewithme testuser <safewithme.testuser@xn--jgeva-dua.com>'
             );
         });
+
+        it('should keep domain as UTF-8 when local part is non-ASCII', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(
+                mb._encodeHeaderValue('from', {
+                    name: 'Jõser',
+                    address: 'jõser@jõgeva.ee'
+                }),
+                '=?UTF-8?Q?J=C3=B5ser?= <jõser@jõgeva.ee>'
+            );
+        });
     });
 
     describe('#_convertAddresses', () => {
@@ -1298,6 +1345,53 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
                 ]),
                 '=?UTF-8?Q?=22J=C3=B5geva_Sass=22?= <a@b.c>'
             );
+        });
+
+        it('should keep domain as UTF-8 when local part is non-ASCII', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(
+                mb._convertAddresses([
+                    {
+                        name: 'Jõgeva Ants',
+                        address: 'jõser@jõgeva.ee'
+                    }
+                ]),
+                '=?UTF-8?Q?J=C3=B5geva_Ants?= <jõser@jõgeva.ee>'
+            );
+        });
+    });
+
+    describe('#_normalizeAddress', () => {
+        it('should punycode the domain when local part is ASCII', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(mb._normalizeAddress('safe@jõgeva.ee'), 'safe@xn--jgeva-dua.ee');
+        });
+
+        it('should keep ASCII domain unchanged', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(mb._normalizeAddress('safe@example.com'), 'safe@example.com');
+        });
+
+        it('should keep domain as UTF-8 when local part is non-ASCII', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(mb._normalizeAddress('jõser@jõgeva.ee'), 'jõser@jõgeva.ee');
+        });
+
+        it('should decode an already punycoded domain when local part is non-ASCII', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(mb._normalizeAddress('jõser@xn--jgeva-dua.ee'), 'jõser@jõgeva.ee');
+        });
+
+        it('should lowercase the domain regardless of branch', () => {
+            let mb = new MimeNode();
+            assert.strictEqual(mb._normalizeAddress('safe@EXAMPLE.COM'), 'safe@example.com');
+            assert.strictEqual(mb._normalizeAddress('jõser@JÕGEVA.EE'), 'jõser@jõgeva.ee');
+        });
+
+        it('should fall back to the supplied domain when punycode throws', () => {
+            let mb = new MimeNode();
+            // 'xn--$.com' is a malformed punycode label that makes punycode.toUnicode throw "Invalid input"
+            assert.strictEqual(mb._normalizeAddress('jõser@xn--$.com'), 'jõser@xn--$.com');
         });
     });
 


### PR DESCRIPTION
## Summary

- When the local part of an email address contains non-ASCII bytes, `MimeNode._normalizeAddress` now calls `punycode.toUnicode` on the domain (decoding any `xn--` labels back) so the rendered header and SMTP envelope are UTF-8 on both sides of `@`. ASCII-only local parts keep current `toASCII` behavior.
- Fixes the pre-existing `${user}@undefined` bug where a `punycode` throw left `encodedDomain` unset; it now falls back to the supplied domain.
- SMTPUTF8 negotiation is unaffected — the existing detection in `lib/smtp-connection/index.js` is a regex over the whole envelope string, so it still triggers when either side of `@` is non-ASCII.

## Test plan

- [x] `npm test` (498 tests pass)
- [x] `npm run lint`
- [x] `npm run test:syntax` (Node 6 syntax-compat)
- [x] New `#_normalizeAddress` describe block covers ASCII-local punycode path, non-ASCII-local UTF-8 path, already-punycoded-domain decode round-trip, lowercasing, and the throw fallback (using a real malformed `xn--$.com` label rather than monkey-patching).
- [x] New tests in `#_convertAddresses`, `#_encodeHeaderValue`, and `#getEnvelope` lock in the header render and envelope paths, including a `setEnvelope` → `getEnvelope` round-trip from punycoded input to UTF-8 output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)