### PR TITLE
chore: drop nodemailer-ntlm-auth devDependency

### DIFF
--- a/examples/ntlm.js
+++ b/examples/ntlm.js
@@ -1,5 +1,10 @@
 /* eslint no-console: 0 */
 
+// To run this example, install the optional NTLM helper alongside nodemailer:
+//   npm install nodemailer-ntlm-auth
+// It is not bundled with nodemailer because of an unfixed transitive
+// underscore advisory (GHSA-qpx9-hpmf-5gmw); the helper is unmaintained.
+
 'use strict';
 
 const nodemailer = require('../lib/nodemailer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "libbase64": "1.3.0",
                 "libmime": "5.3.8",
                 "libqp": "2.1.1",
-                "nodemailer-ntlm-auth": "1.0.4",
                 "prettier": "3.8.3",
                 "proxy": "1.0.2",
                 "proxy-test-server": "1.0.0",
@@ -1909,17 +1908,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/des.js": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-            "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
-            }
-        },
         "node_modules/dtrace-provider": {
             "version": "0.8.8",
             "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
@@ -2376,41 +2364,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/httpntlm": {
-            "version": "1.8.12",
-            "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.12.tgz",
-            "integrity": "sha512-dqdye5b5OmzCIDrA2JgkKG7bV9sK0S5VUELD1+JcRZG6ZDieAW7/c0MPsqlTRKDzso1tIMhvDQAWvfgFN0yg3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://www.paypal.com/donate/?hosted_button_id=2CKNJLZJBW8ZC"
-                },
-                {
-                    "type": "buymeacoffee",
-                    "url": "https://www.buymeacoffee.com/samdecrock"
-                }
-            ],
-            "dependencies": {
-                "des.js": "^1.0.1",
-                "httpreq": ">=0.4.22",
-                "js-md4": "^0.3.2",
-                "underscore": "~1.12.1"
-            },
-            "engines": {
-                "node": ">=10.4.0"
-            }
-        },
-        "node_modules/httpreq": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-1.1.1.tgz",
-            "integrity": "sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.15.1"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2466,7 +2419,8 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/ipv6-normalize": {
             "version": "1.0.1",
@@ -2553,13 +2507,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/js-md4": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
-            "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
@@ -2684,13 +2631,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/minimalistic-assert": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "10.2.5",
@@ -2821,16 +2761,6 @@
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/nodemailer-ntlm-auth": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/nodemailer-ntlm-auth/-/nodemailer-ntlm-auth-1.0.4.tgz",
-            "integrity": "sha512-IkK7/F3k1rqHTl5bf23xHU/bxFu3tSrwBY0hYhpEkpP5o3VlPeY+zJBQwzRF1QO6ROZHhv6KAir77GXUaDvYOA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "httpntlm": "1.8.12"
             }
         },
         "node_modules/once": {
@@ -3236,13 +3166,6 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
-        },
-        "node_modules/underscore": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "libbase64": "1.3.0",
         "libmime": "5.3.8",
         "libqp": "2.1.1",
-        "nodemailer-ntlm-auth": "1.0.4",
         "prettier": "3.8.3",
         "proxy": "1.0.2",
         "proxy-test-server": "1.0.0",


### PR DESCRIPTION
## Summary

- Removes `nodemailer-ntlm-auth` from `devDependencies`. It was only consumed by `examples/ntlm.js` and pulled in a vulnerable transitive `underscore` via `httpntlm` (GHSA-qpx9-hpmf-5gmw, no upstream fix).
- `nodemailer` has zero runtime dependencies, so this chain never reached published consumers — but it produced persistent `npm audit` noise for contributors.
- Adds a header comment to `examples/ntlm.js` instructing readers to `npm install nodemailer-ntlm-auth` themselves before running the example, and explaining why it was removed.

## Test plan

- [x] `npm install` — `found 0 vulnerabilities`
- [x] `npm audit` — clean
- [x] `npm test` — 498/498 pass
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)