### PR TITLE
fix: four listener/stream leaks in SMTP transport, connection, pool

### DIFF
--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -971,7 +971,9 @@ class SMTPConnection extends EventEmitter {
      */
     _onEnd() {
         if (this._socket && !this._socket.destroyed) {
-            this._socket.destroy();
+            // Peer sent FIN — finish our half of the close gracefully rather
+            // than destroying. 'close' fires after the OS finalizes teardown.
+            this._socket.end();
         }
     }
 

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -212,6 +212,13 @@ class SMTPConnection extends EventEmitter {
         this._closing = false;
 
         /**
+         * Message DATA stream currently piped to the socket, if any. Tracked so
+         * close() can unpipe it before tearing the socket down.
+         * @private
+         */
+        this._currentDataStream = false;
+
+        /**
          * Callbacks for socket's listeners
          */
         this._onSocketData = chunk => this._onData(chunk);
@@ -469,6 +476,17 @@ class SMTPConnection extends EventEmitter {
         );
 
         const socket = (this._socket && this._socket.socket) || this._socket;
+
+        // Detach any in-flight DATA stream from the socket so the source stream
+        // can be garbage-collected once the socket is gone.
+        if (this._currentDataStream) {
+            try {
+                this._currentDataStream.unpipe(this._socket);
+            } catch (_E) {
+                // ignore
+            }
+            this._currentDataStream = false;
+        }
 
         if (socket && !socket.destroyed) {
             try {
@@ -1304,6 +1322,7 @@ class SMTPConnection extends EventEmitter {
             });
         }
 
+        this._currentDataStream = dataStream;
         dataStream.pipe(this._socket, {
             end: false
         });
@@ -1325,6 +1344,9 @@ class SMTPConnection extends EventEmitter {
         }
 
         dataStream.once('end', () => {
+            if (this._currentDataStream === dataStream) {
+                this._currentDataStream = false;
+            }
             this.logger.info(
                 {
                     tnx: 'message',

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -1005,6 +1005,15 @@ class SMTPConnection extends EventEmitter {
             opts.servername = this.servername;
         }
 
+        // Remove all listeners from the plain socket to allow proper garbage
+        // collection. Used on both the TLS-success path and the synchronous
+        // tls.connect() throw path; either way the plain socket is done.
+        const removePlainSocketListeners = () => {
+            socketPlain.removeListener('close', this._onSocketClose);
+            socketPlain.removeListener('end', this._onSocketEnd);
+            socketPlain.removeListener('error', this._onSocketError);
+        };
+
         this.upgrading = true;
         // tls.connect is not an asynchronous function however it may still throw errors and requires to be wrapped with try/catch
         try {
@@ -1013,14 +1022,12 @@ class SMTPConnection extends EventEmitter {
                 this.upgrading = false;
                 this._socket.on('data', this._onSocketData);
 
-                // Remove all listeners from the plain socket to allow proper garbage collection
-                socketPlain.removeListener('close', this._onSocketClose);
-                socketPlain.removeListener('end', this._onSocketEnd);
-                socketPlain.removeListener('error', this._onSocketError);
+                removePlainSocketListeners();
 
                 return callback(null, true);
             });
         } catch (err) {
+            removePlainSocketListeners();
             return callback(err);
         }
 

--- a/lib/smtp-transport/index.js
+++ b/lib/smtp-transport/index.js
@@ -151,11 +151,20 @@ class SMTPTransport extends EventEmitter {
 
             const connection = new SMTPConnection(options);
 
+            let perCallAuth;
+            const cleanupPerCallAuth = () => {
+                if (perCallAuth && perCallAuth !== this.auth && perCallAuth.oauth2) {
+                    perCallAuth.oauth2.removeAllListeners();
+                }
+                perCallAuth = null;
+            };
+
             connection.once('error', err => {
                 if (returned) {
                     return;
                 }
                 returned = true;
+                cleanupPerCallAuth();
                 connection.close();
                 return callback(err);
             });
@@ -170,6 +179,7 @@ class SMTPTransport extends EventEmitter {
                         return;
                     }
                     returned = true;
+                    cleanupPerCallAuth();
                     // still have not returned, this means we have an unexpected connection close
                     const err = new Error('Unexpected socket close');
                     if (connection && connection._socket && connection._socket.upgrading) {
@@ -216,6 +226,7 @@ class SMTPTransport extends EventEmitter {
 
                 connection.send(envelope, mail.message.createReadStream(), (err, info) => {
                     returned = true;
+                    cleanupPerCallAuth();
                     connection.close();
                     if (err) {
                         this.logger.error(
@@ -255,13 +266,11 @@ class SMTPTransport extends EventEmitter {
                     return;
                 }
 
-                const auth = this.getAuth(mail.data.auth);
+                perCallAuth = this.getAuth(mail.data.auth);
 
-                if (auth && (connection.allowsAuth || options.forceAuth)) {
-                    connection.login(auth, err => {
-                        if (auth && auth !== this.auth && auth.oauth2) {
-                            auth.oauth2.removeAllListeners();
-                        }
+                if (perCallAuth && (connection.allowsAuth || options.forceAuth)) {
+                    connection.login(perCallAuth, err => {
+                        cleanupPerCallAuth();
                         if (returned) {
                             return;
                         }
@@ -323,12 +332,20 @@ class SMTPTransport extends EventEmitter {
 
             const connection = new SMTPConnection(options);
             let returned = false;
+            let perCallAuth;
+            const cleanupPerCallAuth = () => {
+                if (perCallAuth && perCallAuth !== this.auth && perCallAuth.oauth2) {
+                    perCallAuth.oauth2.removeAllListeners();
+                }
+                perCallAuth = null;
+            };
 
             connection.once('error', err => {
                 if (returned) {
                     return;
                 }
                 returned = true;
+                cleanupPerCallAuth();
                 connection.close();
                 return callback(err);
             });
@@ -338,6 +355,7 @@ class SMTPTransport extends EventEmitter {
                     return;
                 }
                 returned = true;
+                cleanupPerCallAuth();
                 return callback(new Error('Connection closed'));
             });
 
@@ -346,6 +364,7 @@ class SMTPTransport extends EventEmitter {
                     return;
                 }
                 returned = true;
+                cleanupPerCallAuth();
                 connection.quit();
                 return callback(null, true);
             };
@@ -355,10 +374,11 @@ class SMTPTransport extends EventEmitter {
                     return;
                 }
 
-                const authData = this.getAuth({});
+                perCallAuth = this.getAuth({});
 
-                if (authData && (connection.allowsAuth || options.forceAuth)) {
-                    connection.login(authData, err => {
+                if (perCallAuth && (connection.allowsAuth || options.forceAuth)) {
+                    connection.login(perCallAuth, err => {
+                        cleanupPerCallAuth();
                         if (returned) {
                             return;
                         }
@@ -371,11 +391,12 @@ class SMTPTransport extends EventEmitter {
 
                         finalize();
                     });
-                } else if (!authData && connection.allowsAuth && options.forceAuth) {
+                } else if (!perCallAuth && connection.allowsAuth && options.forceAuth) {
                     const err = new Error('Authentication info was not provided');
                     err.code = errors.ENOAUTH;
 
                     returned = true;
+                    cleanupPerCallAuth();
                     connection.close();
                     return callback(err);
                 } else {

--- a/test/smtp-transport/oauth2-listener-leak-test.js
+++ b/test/smtp-transport/oauth2-listener-leak-test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const net = require('node:net');
+const PassThrough = require('node:stream').PassThrough;
+const SMTPTransport = require('../../lib/smtp-transport');
+
+class MockBuilder {
+    constructor(envelope, message, messageId) {
+        this.envelope = envelope;
+        this.rawMessage = message;
+        this.mid = messageId || '<test>';
+    }
+    getEnvelope() {
+        return this.envelope;
+    }
+    messageId() {
+        return this.mid;
+    }
+    createReadStream() {
+        const stream = new PassThrough();
+        setImmediate(() => stream.end(this.rawMessage));
+        return stream;
+    }
+    getHeader() {
+        return 'teretere';
+    }
+}
+
+// Server that advertises XOAUTH2, then forcibly destroys the socket on AUTH
+// to fire connection 'end'/'error' before login()'s callback can run.
+function startDropDuringAuthServer(callback) {
+    const server = net.createServer(socket => {
+        socket.setEncoding('utf8');
+        let buf = '';
+        let greeted = false;
+        socket.write('220 mock.test ESMTP\r\n');
+        socket.on('data', chunk => {
+            buf += chunk;
+            let idx;
+            while ((idx = buf.indexOf('\r\n')) !== -1) {
+                const line = buf.slice(0, idx);
+                buf = buf.slice(idx + 2);
+                if (!greeted && /^EHLO/i.test(line)) {
+                    greeted = true;
+                    socket.write('250-mock.test\r\n250-AUTH XOAUTH2\r\n250 HELP\r\n');
+                } else if (/^AUTH XOAUTH2/i.test(line)) {
+                    // Drop the connection mid-AUTH without replying.
+                    socket.destroy();
+                    return;
+                } else {
+                    socket.write('250 OK\r\n');
+                }
+            }
+        });
+        socket.on('error', () => {});
+    });
+    server.listen(0, () => callback(server, server.address().port));
+}
+
+describe('SMTP Transport OAuth2 listener leak', { timeout: 10000 }, () => {
+    it('cleans up per-call OAuth2 listeners when connection drops during AUTH', (t, done) => {
+        startDropDuringAuthServer((server, port) => {
+            const transport = new SMTPTransport({
+                host: '127.0.0.1',
+                port,
+                ignoreTLS: true,
+                logger: false
+            });
+
+            // Capture the per-call auth object getAuth() builds so we can
+            // assert listener counts after send() returns.
+            let capturedAuth;
+            const originalGetAuth = transport.getAuth.bind(transport);
+            transport.getAuth = function (authOpts) {
+                const result = originalGetAuth(authOpts);
+                if (result && result.type === 'OAUTH2') {
+                    capturedAuth = result;
+                }
+                return result;
+            };
+
+            transport.send(
+                {
+                    data: {
+                        auth: {
+                            type: 'OAuth2',
+                            user: 'user@example.com',
+                            accessToken: 'leak-test-token'
+                        }
+                    },
+                    message: new MockBuilder(
+                        {
+                            from: 'from@example.com',
+                            to: 'to@example.com'
+                        },
+                        'irrelevant'
+                    )
+                },
+                err => {
+                    // Error is expected — the server drops the connection.
+                    assert.ok(err);
+                    assert.ok(capturedAuth, 'per-call OAuth2 instance should have been built');
+                    assert.notStrictEqual(capturedAuth, transport.auth, 'per-call auth must differ from transport.auth');
+                    assert.strictEqual(capturedAuth.oauth2.listenerCount('token'), 0, "'token' listener should have been removed");
+                    assert.strictEqual(capturedAuth.oauth2.listenerCount('error'), 0, "'error' listener should have been removed");
+                    server.close(() => done());
+                }
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes four independent listener / stream leaks surfaced by code review of the SMTP transport, SMTP connection, and SMTP pool layers. One commit per bug.

- **OAuth2 listener leak** (`lib/smtp-transport/index.js`) — when `mail.data.auth` is set, the per-call `XOAuth2` instance attaches `'token'` and `'error'` listeners that were only removed inside `connection.login()`'s callback. If the connection emitted `'error'` or `'end'` during `login()` before its callback fired (server drops mid-AUTH, etc.), the OAuth2 instance was retained and kept the mailer alive through closures. `verify()` had the same class of bug *plus* a worse variant: it always called `getAuth({})` (with `{}` rather than `undefined`), so the short-circuit at the top of `getAuth` never fired and a fresh OAuth2 was built on every `verify()` and never cleaned up at all. Both paths now hoist the per-call auth into a shared closure and call an idempotent `cleanupPerCallAuth()` from every exit. Adds `test/smtp-transport/oauth2-listener-leak-test.js` — a raw-`net` server that drops the socket on AUTH XOAUTH2 and asserts `listenerCount('token')` and `listenerCount('error')` are 0 after the send callback fires (test was confirmed to fail against the pre-fix code).
- **STARTTLS plain-socket listener residue** (`lib/smtp-connection/index.js`) — `_upgradeConnection` wraps `tls.connect()` in `try/catch` because it can throw synchronously. The catch path only ran `callback(err)` and left the plain socket's `close`/`end`/`error` listeners attached. Centralized the removal in a local `removePlainSocketListeners` helper and called it from both the TLS-success callback and the catch branch.
- **In-flight DATA stream pipe leak** (`lib/smtp-connection/index.js`) — `_createSendStream` pipes the message DataStream into the socket with `{ end: false }` and nothing tracked the in-flight stream. If `close()` ran mid-DATA (e.g. a pool resource being closed during a send), the socket was torn down but the source stream stayed piped to a dead destination until GC. Tracks the active stream as `_currentDataStream`: set just before the pipe call, cleared in the stream's `'end'` handler (guarded by identity check), and unpiped in `close()` before the socket teardown.
- **`_onEnd` destroy → end** (`lib/smtp-connection/index.js`) — switched `this._socket.destroy()` to `this._socket.end()` after a clean FIN. Cosmetic — `destroy()` after FIN is rude and inconsistent with the rest of the close path, which already picks `'end'` for non-init stages. Added a brief WHY comment.

### Not fixed: connection-timeout on fallback retry (Bug 5 from review)

The review flagged `_connectionTimeout` as not cleared on the connection-phase fallback retry. On re-reading the code, `_onConnectionError` already clears the timer (`clearTimeout(this._connectionTimeout)`) at the top, *before* the fallback path destroys the socket and re-invokes `_connectToHost` (which arms a fresh timer via `_setupConnectionHandlers`). All other setters of `_connectionTimeout` also pair with a clear. No code change.

### Constraints honored

- `engines.node = ">=6.0.0"` — no `??`, `?.`, class fields, async/await, object spread, or `**`. `npm run test:syntax` (Docker `node:6-alpine` syntax gate) passes.
- No public API changes.
- Verified by a one-off real Ethereal send inside `docker run --rm node:6 …` using callback-style API only — succeeded on `v6.17.1` (`https://ethereal.email/message/…`).

## Test plan

- [x] `npm test` — 499 tests, all pass
- [x] `npm run lint` — clean
- [x] `npm run test:syntax` (Docker `node:6-alpine`) — pass
- [x] Bug 1 focused test (`test/smtp-transport/oauth2-listener-leak-test.js`) — passes on this branch, **fails** against master (confirms the test exercises the leak)
- [x] One-off Node 6 runtime sanity in Docker — real Ethereal send via callback succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
