### PR TITLE
fix: enforce strict TLS for OAuth2 and Ethereal credential requests

### DIFF
--- a/lib/nodemailer.js
+++ b/lib/nodemailer.js
@@ -95,12 +95,22 @@ module.exports.createTestAccount = function (apiUrl, callback) {
         requestHeaders.Authorization = 'Bearer ' + ETHEREAL_API_KEY;
     }
 
-    const req = nmfetch(apiUrl + '/user', {
+    const fetchOptions = {
         contentType: 'application/json',
         method: 'POST',
         headers: requestHeaders,
         body: Buffer.from(JSON.stringify(requestBody))
-    });
+    };
+
+    // Credential-bearing request — opt back into strict cert validation when
+    // the API URL is HTTPS. lib/fetch defaults to rejectUnauthorized:false
+    // for attachment hosts that may be self-signed; the Ethereal API has a
+    // real cert, so the lax default was a free attack surface.
+    if (/^https:/i.test(apiUrl)) {
+        fetchOptions.tls = { rejectUnauthorized: true };
+    }
+
+    const req = nmfetch(apiUrl + '/user', fetchOptions);
 
     req.on('readable', () => {
         let chunk;

--- a/lib/xoauth2/index.js
+++ b/lib/xoauth2/index.js
@@ -33,6 +33,7 @@ const errors = require('../errors');
  * @param {Number} options.expires Optional Access Token expire time in ms
  * @param {Number} options.timeout Optional TTL for Access Token in seconds
  * @param {Function} options.provisionCallback Function to run when a new access token is required
+ * @param {Object} options.tls Optional TLS options forwarded to the HTTPS token request. Defaults to strict cert validation; supply { rejectUnauthorized: false } only for self-hosted OAuth providers on private CAs.
  */
 class XOAuth2 extends Stream {
     constructor(options, logger) {
@@ -370,12 +371,24 @@ class XOAuth2 extends Stream {
         const chunks = [];
         let chunklen = 0;
 
-        const req = nmfetch(url, {
+        const fetchOptions = {
             method: 'post',
             headers: params.customHeaders,
             body: payload,
             allowErrorResponse: true
-        });
+        };
+
+        // OAuth2 token endpoints are credential-bearing. lib/fetch defaults to
+        // rejectUnauthorized:false (intentional for self-signed attachment
+        // hosts), so opt back in to strict cert validation here when the
+        // access URL is HTTPS. params.tls (the user's options.tls) is layered
+        // on top so callers with a self-hosted provider on a private CA can
+        // still override.
+        if (/^https:/i.test(url)) {
+            fetchOptions.tls = Object.assign({ rejectUnauthorized: true }, params.tls || {});
+        }
+
+        const req = nmfetch(url, fetchOptions);
 
         req.on('readable', () => {
             let chunk;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "Easy as cake e-mail sending from your Node.js applications",
     "main": "lib/nodemailer.js",
     "scripts": {
-        "test": "node --test --test-concurrency=1 test/**/*.test.js test/**/*-test.js",
-        "test:coverage": "c8 node --test --test-concurrency=1 test/**/*.test.js test/**/*-test.js",
+        "test": "node --test --test-concurrency=1 $(find test \\( -name '*-test.js' -o -name '*.test.js' \\))",
+        "test:coverage": "c8 node --test --test-concurrency=1 $(find test \\( -name '*-test.js' -o -name '*.test.js' \\))",
         "format": "prettier --write \"**/*.{js,json,md}\"",
         "format:check": "prettier --check \"**/*.{js,json,md}\"",
         "lint": "eslint .",

--- a/test/ethereal-test.js
+++ b/test/ethereal-test.js
@@ -4,7 +4,10 @@ const nodemailer = require('../lib/nodemailer');
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-describe('Ethereal Tests', { timeout: 50 * 1000 }, () => {
+// These tests hit the real api.nodemailer.com endpoint and send through
+// the actual Ethereal SMTP server, so they need network + working external
+// services. Opt in with NODEMAILER_INTEGRATION_TESTS=1 to run them.
+describe('Ethereal Tests', { timeout: 50 * 1000, skip: !process.env.NODEMAILER_INTEGRATION_TESTS }, () => {
     it('should create an account and send a message', (t, done) => {
         // Generate SMTP service account from ethereal.email
         nodemailer.createTestAccount((err, account) => {

--- a/test/nodemailer/ethereal-tls-test.js
+++ b/test/nodemailer/ethereal-tls-test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const https = require('node:https');
+const nodemailer = require('../../lib/nodemailer');
+
+// Self-signed cert reused from test/fetch/nmfetch-test.js — keeps this test
+// self-contained per the repo's per-file-copy convention.
+const httpsOptions = {
+    key:
+        '-----BEGIN RSA PRIVATE KEY-----\n' +
+        'MIIEpAIBAAKCAQEA6Z5Qqhw+oWfhtEiMHE32Ht94mwTBpAfjt3vPpX8M7DMCTwHs\n' +
+        '1xcXvQ4lQ3rwreDTOWdoJeEEy7gMxXqH0jw0WfBx+8IIJU69xstOyT7FRFDvA1yT\n' +
+        'RXY2yt9K5s6SKken/ebMfmZR+03ND4UFsDzkz0FfgcjrkXmrMF5Eh5UXX/+9YHeU\n' +
+        'xlp0gMAt+/SumSmgCaysxZLjLpd4uXz+X+JVxsk1ACg1NoEO7lWJC/3WBP7MIcu2\n' +
+        'wVsMd2XegLT0gWYfT1/jsIH64U/mS/SVXC9QhxMl9Yfko2kx1OiYhDxhHs75RJZh\n' +
+        'rNRxgfiwgSb50Gw4NAQaDIxr/DJPdLhgnpY6UQIDAQABAoIBAE+tfzWFjJbgJ0ql\n' +
+        's6Ozs020Sh4U8TZQuonJ4HhBbNbiTtdDgNObPK1uNadeNtgW5fOeIRdKN6iDjVeN\n' +
+        'AuXhQrmqGDYVZ1HSGUfD74sTrZQvRlWPLWtzdhybK6Css41YAyPFo9k4bJ2ZW2b/\n' +
+        'p4EEQ8WsNja9oBpttMU6YYUchGxo1gujN8hmfDdXUQx3k5Xwx4KA68dveJ8GasIt\n' +
+        'd+0Jd/FVwCyyx8HTiF1FF8QZYQeAXxbXJgLBuCsMQJghlcpBEzWkscBR3Ap1U0Zi\n' +
+        '4oat8wrPZGCblaA6rNkRUVbc/+Vw0stnuJ/BLHbPxyBs6w495yBSjBqUWZMvljNz\n' +
+        'm9/aK0ECgYEA9oVIVAd0enjSVIyAZNbw11ElidzdtBkeIJdsxqhmXzeIFZbB39Gd\n' +
+        'bjtAVclVbq5mLsI1j22ER2rHA4Ygkn6vlLghK3ZMPxZa57oJtmL3oP0RvOjE4zRV\n' +
+        'dzKexNGo9gU/x9SQbuyOmuauvAYhXZxeLpv+lEfsZTqqrvPUGeBiEQcCgYEA8poG\n' +
+        'WVnykWuTmCe0bMmvYDsWpAEiZnFLDaKcSbz3O7RMGbPy1cypmqSinIYUpURBT/WY\n' +
+        'wVPAGtjkuTXtd1Cy58m7PqziB7NNWMcsMGj+lWrTPZ6hCHIBcAImKEPpd+Y9vGJX\n' +
+        'oatFJguqAGOz7rigBq6iPfeQOCWpmprNAuah++cCgYB1gcybOT59TnA7mwlsh8Qf\n' +
+        'bm+tSllnin2A3Y0dGJJLmsXEPKtHS7x2Gcot2h1d98V/TlWHe5WNEUmx1VJbYgXB\n' +
+        'pw8wj2ACxl4ojNYqWPxegaLd4DpRbtW6Tqe9e47FTnU7hIggR6QmFAWAXI+09l8y\n' +
+        'amssNShqjE9lu5YDi6BTKwKBgQCuIlKGViLfsKjrYSyHnajNWPxiUhIgGBf4PI0T\n' +
+        '/Jg1ea/aDykxv0rKHnw9/5vYGIsM2st/kR7l5mMecg/2Qa145HsLfMptHo1ZOPWF\n' +
+        '9gcuttPTegY6aqKPhGthIYX2MwSDMM+X0ri6m0q2JtqjclAjG7yG4CjbtGTt/UlE\n' +
+        'WMlSZwKBgQDslGeLUnkW0bsV5EG3AKRUyPKz/6DVNuxaIRRhOeWVKV101claqXAT\n' +
+        'wXOpdKrvkjZbT4AzcNrlGtRl3l7dEVXTu+dN7/ZieJRu7zaStlAQZkIyP9O3DdQ3\n' +
+        'rIcetQpfrJ1cAqz6Ng0pD0mh77vQ13WG1BBmDFa2A9BuzLoBituf4g==\n' +
+        '-----END RSA PRIVATE KEY-----',
+    cert:
+        '-----BEGIN CERTIFICATE-----\n' +
+        'MIICpDCCAYwCCQCuVLVKVTXnAjANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwls\n' +
+        'b2NhbGhvc3QwHhcNMTUwMjEyMTEzMjU4WhcNMjUwMjA5MTEzMjU4WjAUMRIwEAYD\n' +
+        'VQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDp\n' +
+        'nlCqHD6hZ+G0SIwcTfYe33ibBMGkB+O3e8+lfwzsMwJPAezXFxe9DiVDevCt4NM5\n' +
+        'Z2gl4QTLuAzFeofSPDRZ8HH7wgglTr3Gy07JPsVEUO8DXJNFdjbK30rmzpIqR6f9\n' +
+        '5sx+ZlH7Tc0PhQWwPOTPQV+ByOuReaswXkSHlRdf/71gd5TGWnSAwC379K6ZKaAJ\n' +
+        'rKzFkuMul3i5fP5f4lXGyTUAKDU2gQ7uVYkL/dYE/swhy7bBWwx3Zd6AtPSBZh9P\n' +
+        'X+OwgfrhT+ZL9JVcL1CHEyX1h+SjaTHU6JiEPGEezvlElmGs1HGB+LCBJvnQbDg0\n' +
+        'BBoMjGv8Mk90uGCeljpRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABXm8GPdY0sc\n' +
+        'mMUFlgDqFzcevjdGDce0QfboR+M7WDdm512Jz2SbRTgZD/4na42ThODOZz9z1AcM\n' +
+        'zLgx2ZNZzVhBz0odCU4JVhOCEks/OzSyKeGwjIb4JAY7dh+Kju1+6MNfQJ4r1Hza\n' +
+        'SVXH0+JlpJDaJ73NQ2JyfqELmJ1mTcptkA/N6rQWhlzycTBSlfogwf9xawgVPATP\n' +
+        '4AuwgjHl12JI2HVVs1gu65Y3slvaHRCr0B4+Kg1GYNLLcbFcK+NEHrHmPxy9TnTh\n' +
+        'Zwp1dsNQU+Xkylz8IUANWSLHYZOMtN2e5SKIdwTtl5C8YxveuY8YKb1gDExnMraT\n' +
+        'VGXQDqPleug=\n' +
+        '-----END CERTIFICATE-----'
+};
+
+describe('createTestAccount strict TLS', { timeout: 10000 }, () => {
+    let server;
+    let apiUrl;
+
+    beforeEach((t, done) => {
+        server = https.createServer(httpsOptions, (req, res) => {
+            req.resume();
+            req.on('end', () => {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ status: 'success', user: 'u', pass: 'p', smtp: { host: 'x', port: 587, secure: false } }));
+            });
+        });
+        server.listen(0, () => {
+            apiUrl = 'https://localhost:' + server.address().port;
+            done();
+        });
+    });
+
+    afterEach((t, done) => {
+        server.close(done);
+    });
+
+    it('rejects self-signed HTTPS Ethereal API endpoints by default', (t, done) => {
+        nodemailer.createTestAccount(apiUrl, (err, account) => {
+            assert.ok(err, 'expected TLS error');
+            // lib/fetch overwrites err.code with EFETCH; the underlying TLS
+            // reason stays in err.message (self-signed, expired, etc.).
+            assert.ok(
+                /certificate|self.?signed|unable to verify/i.test(err.message),
+                'expected TLS cert error in message, got: ' + err.message
+            );
+            assert.ok(!account);
+            done();
+        });
+    });
+});

--- a/test/xoauth2/xoauth2-tls-test.js
+++ b/test/xoauth2/xoauth2-tls-test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const https = require('node:https');
+const XOAuth2 = require('../../lib/xoauth2');
+
+// Self-signed cert reused from test/fetch/nmfetch-test.js — keeps this test
+// self-contained per the repo's per-file-copy convention.
+const httpsOptions = {
+    key:
+        '-----BEGIN RSA PRIVATE KEY-----\n' +
+        'MIIEpAIBAAKCAQEA6Z5Qqhw+oWfhtEiMHE32Ht94mwTBpAfjt3vPpX8M7DMCTwHs\n' +
+        '1xcXvQ4lQ3rwreDTOWdoJeEEy7gMxXqH0jw0WfBx+8IIJU69xstOyT7FRFDvA1yT\n' +
+        'RXY2yt9K5s6SKken/ebMfmZR+03ND4UFsDzkz0FfgcjrkXmrMF5Eh5UXX/+9YHeU\n' +
+        'xlp0gMAt+/SumSmgCaysxZLjLpd4uXz+X+JVxsk1ACg1NoEO7lWJC/3WBP7MIcu2\n' +
+        'wVsMd2XegLT0gWYfT1/jsIH64U/mS/SVXC9QhxMl9Yfko2kx1OiYhDxhHs75RJZh\n' +
+        'rNRxgfiwgSb50Gw4NAQaDIxr/DJPdLhgnpY6UQIDAQABAoIBAE+tfzWFjJbgJ0ql\n' +
+        's6Ozs020Sh4U8TZQuonJ4HhBbNbiTtdDgNObPK1uNadeNtgW5fOeIRdKN6iDjVeN\n' +
+        'AuXhQrmqGDYVZ1HSGUfD74sTrZQvRlWPLWtzdhybK6Css41YAyPFo9k4bJ2ZW2b/\n' +
+        'p4EEQ8WsNja9oBpttMU6YYUchGxo1gujN8hmfDdXUQx3k5Xwx4KA68dveJ8GasIt\n' +
+        'd+0Jd/FVwCyyx8HTiF1FF8QZYQeAXxbXJgLBuCsMQJghlcpBEzWkscBR3Ap1U0Zi\n' +
+        '4oat8wrPZGCblaA6rNkRUVbc/+Vw0stnuJ/BLHbPxyBs6w495yBSjBqUWZMvljNz\n' +
+        'm9/aK0ECgYEA9oVIVAd0enjSVIyAZNbw11ElidzdtBkeIJdsxqhmXzeIFZbB39Gd\n' +
+        'bjtAVclVbq5mLsI1j22ER2rHA4Ygkn6vlLghK3ZMPxZa57oJtmL3oP0RvOjE4zRV\n' +
+        'dzKexNGo9gU/x9SQbuyOmuauvAYhXZxeLpv+lEfsZTqqrvPUGeBiEQcCgYEA8poG\n' +
+        'WVnykWuTmCe0bMmvYDsWpAEiZnFLDaKcSbz3O7RMGbPy1cypmqSinIYUpURBT/WY\n' +
+        'wVPAGtjkuTXtd1Cy58m7PqziB7NNWMcsMGj+lWrTPZ6hCHIBcAImKEPpd+Y9vGJX\n' +
+        'oatFJguqAGOz7rigBq6iPfeQOCWpmprNAuah++cCgYB1gcybOT59TnA7mwlsh8Qf\n' +
+        'bm+tSllnin2A3Y0dGJJLmsXEPKtHS7x2Gcot2h1d98V/TlWHe5WNEUmx1VJbYgXB\n' +
+        'pw8wj2ACxl4ojNYqWPxegaLd4DpRbtW6Tqe9e47FTnU7hIggR6QmFAWAXI+09l8y\n' +
+        'amssNShqjE9lu5YDi6BTKwKBgQCuIlKGViLfsKjrYSyHnajNWPxiUhIgGBf4PI0T\n' +
+        '/Jg1ea/aDykxv0rKHnw9/5vYGIsM2st/kR7l5mMecg/2Qa145HsLfMptHo1ZOPWF\n' +
+        '9gcuttPTegY6aqKPhGthIYX2MwSDMM+X0ri6m0q2JtqjclAjG7yG4CjbtGTt/UlE\n' +
+        'WMlSZwKBgQDslGeLUnkW0bsV5EG3AKRUyPKz/6DVNuxaIRRhOeWVKV101claqXAT\n' +
+        'wXOpdKrvkjZbT4AzcNrlGtRl3l7dEVXTu+dN7/ZieJRu7zaStlAQZkIyP9O3DdQ3\n' +
+        'rIcetQpfrJ1cAqz6Ng0pD0mh77vQ13WG1BBmDFa2A9BuzLoBituf4g==\n' +
+        '-----END RSA PRIVATE KEY-----',
+    cert:
+        '-----BEGIN CERTIFICATE-----\n' +
+        'MIICpDCCAYwCCQCuVLVKVTXnAjANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwls\n' +
+        'b2NhbGhvc3QwHhcNMTUwMjEyMTEzMjU4WhcNMjUwMjA5MTEzMjU4WjAUMRIwEAYD\n' +
+        'VQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDp\n' +
+        'nlCqHD6hZ+G0SIwcTfYe33ibBMGkB+O3e8+lfwzsMwJPAezXFxe9DiVDevCt4NM5\n' +
+        'Z2gl4QTLuAzFeofSPDRZ8HH7wgglTr3Gy07JPsVEUO8DXJNFdjbK30rmzpIqR6f9\n' +
+        '5sx+ZlH7Tc0PhQWwPOTPQV+ByOuReaswXkSHlRdf/71gd5TGWnSAwC379K6ZKaAJ\n' +
+        'rKzFkuMul3i5fP5f4lXGyTUAKDU2gQ7uVYkL/dYE/swhy7bBWwx3Zd6AtPSBZh9P\n' +
+        'X+OwgfrhT+ZL9JVcL1CHEyX1h+SjaTHU6JiEPGEezvlElmGs1HGB+LCBJvnQbDg0\n' +
+        'BBoMjGv8Mk90uGCeljpRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABXm8GPdY0sc\n' +
+        'mMUFlgDqFzcevjdGDce0QfboR+M7WDdm512Jz2SbRTgZD/4na42ThODOZz9z1AcM\n' +
+        'zLgx2ZNZzVhBz0odCU4JVhOCEks/OzSyKeGwjIb4JAY7dh+Kju1+6MNfQJ4r1Hza\n' +
+        'SVXH0+JlpJDaJ73NQ2JyfqELmJ1mTcptkA/N6rQWhlzycTBSlfogwf9xawgVPATP\n' +
+        '4AuwgjHl12JI2HVVs1gu65Y3slvaHRCr0B4+Kg1GYNLLcbFcK+NEHrHmPxy9TnTh\n' +
+        'Zwp1dsNQU+Xkylz8IUANWSLHYZOMtN2e5SKIdwTtl5C8YxveuY8YKb1gDExnMraT\n' +
+        'VGXQDqPleug=\n' +
+        '-----END CERTIFICATE-----'
+};
+
+describe('XOAuth2 strict TLS for token requests', { timeout: 10000 }, () => {
+    let server;
+    let accessUrl;
+
+    beforeEach((t, done) => {
+        server = https.createServer(httpsOptions, (req, res) => {
+            req.resume();
+            req.on('end', () => {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ access_token: 'minted-by-self-signed-server', expires_in: 3600 }));
+            });
+        });
+        server.listen(0, () => {
+            accessUrl = 'https://localhost:' + server.address().port + '/token';
+            done();
+        });
+    });
+
+    afterEach((t, done) => {
+        server.close(done);
+    });
+
+    it('rejects self-signed HTTPS OAuth2 endpoints by default', (t, done) => {
+        const auth = new XOAuth2({
+            user: 'user@example.com',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            refreshToken: 'rtoken',
+            accessUrl
+        });
+
+        auth.getToken(true, (err, token) => {
+            assert.ok(err, 'expected TLS error');
+            // lib/fetch overwrites err.code with EFETCH but preserves the
+            // underlying TLS reason in err.message. Match any cert-validation
+            // failure (self-signed, expired, unable to verify, etc.) — the
+            // exact wording depends on the embedded cert and OpenSSL build.
+            assert.ok(
+                /certificate|self.?signed|unable to verify/i.test(err.message),
+                'expected TLS cert error in message, got: ' + err.message
+            );
+            assert.ok(!token);
+            done();
+        });
+    });
+
+    it('accepts self-signed HTTPS OAuth2 endpoints when options.tls overrides', (t, done) => {
+        const auth = new XOAuth2({
+            user: 'user@example.com',
+            clientId: 'cid',
+            clientSecret: 'csecret',
+            refreshToken: 'rtoken',
+            accessUrl,
+            tls: { rejectUnauthorized: false }
+        });
+
+        auth.getToken(true, (err, token) => {
+            assert.ok(!err, 'expected success, got: ' + (err && err.message));
+            assert.strictEqual(token, 'minted-by-self-signed-server');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`lib/fetch` is intentionally lax (`rejectUnauthorized: false` hardcoded at `lib/fetch/index.js:126`) because most fetch calls in nodemailer target attachment hosts that are often internal or self-signed. **Credential-bearing endpoints are different**: an attacker positioned to MITM these requests can silently exfiltrate the bearer token (OAuth2) or test-account credentials (Ethereal). Both endpoints involved (`accounts.google.com/o/oauth2/token` and `api.nodemailer.com`) ship perfectly valid certs, so the lax default was opening real attack surface for no benefit.

This PR opts those two specific call sites back into strict TLS validation, and incidentally fixes a separate test-glob quirk that was hiding top-level test files from CI. It does **not** change the default behavior of `lib/fetch` for any other caller.

### Commits

**1. `fix: enforce strict TLS validation for OAuth2 token requests`** — `lib/xoauth2/index.js` `postRequest()` now passes `tls: { rejectUnauthorized: true }` to `nmfetch` when the access URL is HTTPS. The user's `options.tls` is layered on top, so self-hosted OAuth providers running on a private CA can still opt out:

```js
new XOAuth2({
  user: '...',
  clientId: '...',
  clientSecret: '...',
  refreshToken: '...',
  accessUrl: 'https://oauth.internal.example.com/token',
  tls: { rejectUnauthorized: false } // explicit opt-out, documented
});
```

**2. `fix: enforce strict TLS validation for createTestAccount`** — `lib/nodemailer.js` `createTestAccount` likewise passes `tls: { rejectUnauthorized: true }` when the API URL is HTTPS. No per-call escape hatch (the function signature is `(apiUrl, callback)` — adding `options` would be a public API change for marginal benefit). Anyone needing to point at an HTTPS dev server with a private CA can set `NODE_TLS_REJECT_UNAUTHORIZED=0` at the process level, which is the standard Node dev pattern.

**3. `test: fix npm test glob so top-level test files are picked up`** — surfaced while adding the createTestAccount test. The `test` / `test:coverage` scripts used `test/**/*-test.js`, but `/bin/sh` and `bash` without `globstar` treat `**` as a single `*`, so the pattern silently degraded to `test/*/*-test.js` and only matched files exactly one directory deep. `test/ethereal-test.js` had been quietly excluded from CI since the native-runner migration in #1604. Swapped both scripts to a `find`-based recursion that works in `/bin/sh`, `/bin/bash`, and `dash`. Also gated `test/ethereal-test.js` on `NODEMAILER_INTEGRATION_TESTS=1` since it hits the real Ethereal API and SMTP — the suite shows up as `SKIP` in normal runs and runs in full when the env var is set.

HTTP URLs are unaffected in both TLS fixes — no TLS code path is even touched. That includes the existing `test/xoauth2/xoauth2-test.js` (HTTP localhost mock).

### Tests added

- `test/xoauth2/xoauth2-tls-test.js` — self-signed HTTPS server; default refuses cert, `options.tls` override accepts.
- `test/nodemailer/ethereal-tls-test.js` — self-signed HTTPS server; `createTestAccount` refuses cert.

Both new "rejects self-signed" tests were confirmed to **fail against master** and pass on this branch.

### Considered alternatives

- **Tightening `lib/fetch`'s global default**: would break attachment fetches against self-signed/internal hosts and the broader ecosystem that relies on the lax default. Rejected.
- **Adding an `options` arg to `createTestAccount`** for a `tls` override: rejected — public API change for a vanishingly rare use case. `NODE_TLS_REJECT_UNAUTHORIZED=0` covers it.

## Test plan

- [x] `npm test` — 501 tests, all pass (+2 new); previously-orphaned `test/ethereal-test.js` now appears as `SKIP`
- [x] `NODEMAILER_INTEGRATION_TESTS=1 node --test test/ethereal-test.js` — env-gated suite runs and passes (3 tests against real Ethereal)
- [x] `npm run lint` — clean
- [x] `npm run test:syntax` (Docker `node:6-alpine` syntax gate) — pass
- [x] Both new "rejects self-signed" tests fail against master without the lib change (confirms they exercise the fix)
- [x] Existing `test/xoauth2/xoauth2-test.js` unaffected (uses HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
