### PR TITLE
fix: two pending security advisories (jsonTransport access bypass, List-* CRLF injection)

### DIFF
--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -407,31 +407,39 @@ class Mail extends EventEmitter {
         if ((!this.options.attachDataUrls && !mail.data.attachDataUrls) || !mail.data.html) {
             return callback();
         }
-        mail.resolveContent(mail.data, 'html', (err, html) => {
-            if (err) {
-                return callback(err);
+        mail.resolveContent(
+            mail.data,
+            'html',
+            { disableFileAccess: mail.data.disableFileAccess, disableUrlAccess: mail.data.disableUrlAccess },
+            (err, html) => {
+                if (err) {
+                    return callback(err);
+                }
+                let cidCounter = 0;
+                html = (html || '')
+                    .toString()
+                    .replace(
+                        /(<img\b[^<>]{0,1024} src\s{0,20}=[\s"']{0,20})(data:([^;]+);[^"'>\s]+)/gi,
+                        (match, prefix, dataUri, mimeType) => {
+                            const cid = crypto.randomBytes(10).toString('hex') + '@localhost';
+                            if (!mail.data.attachments) {
+                                mail.data.attachments = [];
+                            }
+                            if (!Array.isArray(mail.data.attachments)) {
+                                mail.data.attachments = [].concat(mail.data.attachments || []);
+                            }
+                            mail.data.attachments.push({
+                                path: dataUri,
+                                cid,
+                                filename: 'image-' + ++cidCounter + '.' + mimeTypes.detectExtension(mimeType)
+                            });
+                            return prefix + 'cid:' + cid;
+                        }
+                    );
+                mail.data.html = html;
+                callback();
             }
-            let cidCounter = 0;
-            html = (html || '')
-                .toString()
-                .replace(/(<img\b[^<>]{0,1024} src\s{0,20}=[\s"']{0,20})(data:([^;]+);[^"'>\s]+)/gi, (match, prefix, dataUri, mimeType) => {
-                    const cid = crypto.randomBytes(10).toString('hex') + '@localhost';
-                    if (!mail.data.attachments) {
-                        mail.data.attachments = [];
-                    }
-                    if (!Array.isArray(mail.data.attachments)) {
-                        mail.data.attachments = [].concat(mail.data.attachments || []);
-                    }
-                    mail.data.attachments.push({
-                        path: dataUri,
-                        cid,
-                        filename: 'image-' + ++cidCounter + '.' + mimeTypes.detectExtension(mimeType)
-                    });
-                    return prefix + 'cid:' + cid;
-                });
-            mail.data.html = html;
-            callback();
-        });
+        );
     }
 
     set(key, value) {

--- a/lib/mailer/mail-message.js
+++ b/lib/mailer/mail-message.js
@@ -111,25 +111,29 @@ class MailMessage {
             if (!args[0] || !args[0][args[1]]) {
                 return resolveNext();
             }
-            shared.resolveContent(...args, (err, value) => {
-                if (err) {
-                    return callback(err);
-                }
+            shared.resolveContent(
+                ...args,
+                { disableFileAccess: this.data.disableFileAccess, disableUrlAccess: this.data.disableUrlAccess },
+                (err, value) => {
+                    if (err) {
+                        return callback(err);
+                    }
 
-                const node = {
-                    content: value
-                };
-                if (args[0][args[1]] && typeof args[0][args[1]] === 'object' && !Buffer.isBuffer(args[0][args[1]])) {
-                    Object.keys(args[0][args[1]]).forEach(key => {
-                        if (!(key in node) && !['content', 'path', 'href', 'raw'].includes(key)) {
-                            node[key] = args[0][args[1]][key];
-                        }
-                    });
-                }
+                    const node = {
+                        content: value
+                    };
+                    if (args[0][args[1]] && typeof args[0][args[1]] === 'object' && !Buffer.isBuffer(args[0][args[1]])) {
+                        Object.keys(args[0][args[1]]).forEach(key => {
+                            if (!(key in node) && !['content', 'path', 'href', 'raw'].includes(key)) {
+                                node[key] = args[0][args[1]][key];
+                            }
+                        });
+                    }
 
-                args[0][args[1]] = node;
-                resolveNext();
-            });
+                    args[0][args[1]] = node;
+                    resolveNext();
+                }
+            );
         };
 
         setImmediate(() => resolveNext());
@@ -269,7 +273,8 @@ class MailMessage {
                         if (value && value.url) {
                             if (key.toLowerCase().trim() === 'id') {
                                 // List-ID: "comment" <domain>
-                                let comment = value.comment || '';
+                                // strip CR/LF so a comment can't inject extra header lines
+                                let comment = (value.comment || '').toString().replace(/\r?\n|\r/g, ' ');
                                 if (mimeFuncs.isPlainText(comment)) {
                                     comment = '"' + comment + '"';
                                 } else {
@@ -280,7 +285,8 @@ class MailMessage {
                             }
 
                             // List-*: <http://domain> (comment)
-                            let comment = value.comment || '';
+                            // strip CR/LF so a comment can't inject extra header lines
+                            let comment = (value.comment || '').toString().replace(/\r?\n|\r/g, ' ');
                             if (!mimeFuncs.isPlainText(comment)) {
                                 comment = mimeFuncs.encodeWord(comment);
                             }

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -6,6 +6,7 @@ const urllib = require('url');
 const util = require('util');
 const fs = require('fs');
 const nmfetch = require('../fetch');
+const errors = require('../errors');
 const dns = require('dns');
 const net = require('net');
 const os = require('os');
@@ -501,9 +502,17 @@ module.exports.parseDataURI = uri => {
  *
  * @param {Object} data An object or an Array you want to resolve an element for
  * @param {String|Number} key Property name or an Array index
+ * @param {Object} [options] Optional access policy: { disableFileAccess, disableUrlAccess }
  * @param {Function} callback Callback function with (err, value)
  */
-module.exports.resolveContent = (data, key, callback) => {
+module.exports.resolveContent = (data, key, options, callback) => {
+    // options is optional; support the legacy resolveContent(data, key, callback) signature
+    if (!callback && typeof options === 'function') {
+        callback = options;
+        options = false;
+    }
+    options = options || {};
+
     let promise;
 
     if (!callback) {
@@ -538,6 +547,13 @@ module.exports.resolveContent = (data, key, callback) => {
                 callback(null, value);
             });
         } else if (/^https?:\/\//i.test(content.path || content.href)) {
+            if (options.disableUrlAccess) {
+                return setImmediate(() => {
+                    const err = new Error('Url access rejected for ' + (content.path || content.href));
+                    err.code = errors.EURLACCESS;
+                    callback(err);
+                });
+            }
             return resolveStream(nmfetch(content.path || content.href), callback);
         } else if (/^data:/i.test(content.path || content.href)) {
             const parsedDataUri = module.exports.parseDataURI(content.path || content.href);
@@ -547,6 +563,13 @@ module.exports.resolveContent = (data, key, callback) => {
             }
             return callback(null, parsedDataUri.data);
         } else if (content.path) {
+            if (options.disableFileAccess) {
+                return setImmediate(() => {
+                    const err = new Error('File access rejected for ' + content.path);
+                    err.code = errors.EFILEACCESS;
+                    callback(err);
+                });
+            }
             return resolveStream(fs.createReadStream(content.path), callback);
         }
     }

--- a/test/json-transport/json-transport-test.js
+++ b/test/json-transport/json-transport-test.js
@@ -2,8 +2,9 @@
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-const { describe, it } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('http');
 const nodemailer = require('../../lib/nodemailer');
 
 describe('JSON Transport Tests', () => {
@@ -144,5 +145,129 @@ describe('JSON Transport Tests', () => {
             });
             done();
         });
+    });
+});
+
+describe('JSON Transport access control (disableFileAccess / disableUrlAccess)', () => {
+    let port = 10399;
+    let server;
+
+    before((t, done) => {
+        server = http.createServer((req, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('SECRET_URL_BODY');
+        });
+        server.listen(port, done);
+    });
+
+    after((t, done) => {
+        server.close(done);
+    });
+
+    it('should reject attachment file access when disableFileAccess is set', (t, done) => {
+        let transport = nodemailer.createTransport({
+            jsonTransport: true,
+            disableFileAccess: true
+        });
+
+        transport.sendMail(
+            {
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'file',
+                text: 'body',
+                attachments: [{ filename: 'secret.txt', path: __dirname + '/fixtures/body.html' }]
+            },
+            err => {
+                assert.ok(err);
+                assert.strictEqual(err.code, 'EFILEACCESS');
+                done();
+            }
+        );
+    });
+
+    it('should reject URL content access when disableUrlAccess is set', (t, done) => {
+        let transport = nodemailer.createTransport({
+            jsonTransport: true,
+            disableUrlAccess: true
+        });
+
+        transport.sendMail(
+            {
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'url',
+                text: { href: 'http://127.0.0.1:' + port + '/private' }
+            },
+            err => {
+                assert.ok(err);
+                assert.strictEqual(err.code, 'EURLACCESS');
+                done();
+            }
+        );
+    });
+
+    it('should reject attachDataUrls html file access when disableFileAccess is set', (t, done) => {
+        let transport = nodemailer.createTransport({
+            jsonTransport: true,
+            attachDataUrls: true,
+            disableFileAccess: true
+        });
+
+        transport.sendMail(
+            {
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'datauri',
+                html: { path: __dirname + '/fixtures/body.html' }
+            },
+            err => {
+                assert.ok(err);
+                assert.strictEqual(err.code, 'EFILEACCESS');
+                done();
+            }
+        );
+    });
+
+    it('should still resolve file attachments when the flags are not set', (t, done) => {
+        let transport = nodemailer.createTransport({
+            jsonTransport: true
+        });
+
+        transport.sendMail(
+            {
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'file',
+                text: 'body',
+                attachments: [{ filename: 'body.html', path: __dirname + '/fixtures/body.html' }]
+            },
+            (err, info) => {
+                assert.ok(!err);
+                let message = JSON.parse(info.message);
+                assert.ok(message.attachments[0].content);
+                done();
+            }
+        );
+    });
+
+    it('should still resolve URL content when the flags are not set', (t, done) => {
+        let transport = nodemailer.createTransport({
+            jsonTransport: true
+        });
+
+        transport.sendMail(
+            {
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'url',
+                text: { href: 'http://127.0.0.1:' + port + '/private' }
+            },
+            (err, info) => {
+                assert.ok(!err);
+                assert.strictEqual(JSON.parse(info.message).text, 'SECRET_URL_BODY');
+                done();
+            }
+        );
     });
 });

--- a/test/nodemailer/list-headers-test.js
+++ b/test/nodemailer/list-headers-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const nodemailer = require('../../lib/nodemailer');
+
+// Regression tests for GHSA-268h-hp4c-crq3: CRLF in a `list.*.comment` field
+// must not be emitted as a real header boundary in the generated message.
+describe('List-* header comment CRLF injection', () => {
+    const send = data => {
+        const transport = nodemailer.createTransport({ streamTransport: true, buffer: true });
+        return new Promise((resolve, reject) => {
+            transport.sendMail(data, (err, info) => (err ? reject(err) : resolve(info.message.toString('utf8'))));
+        });
+    };
+
+    const listKeys = ['help', 'unsubscribe', 'subscribe', 'post', 'owner', 'archive', 'id'];
+
+    listKeys.forEach(key => {
+        it('should not allow header injection via list.' + key + '.comment', async () => {
+            const raw = await send({
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'list ' + key,
+                list: {
+                    [key]: {
+                        url: key === 'id' ? 'example.test' : 'https://example.test/' + key,
+                        comment: 'comment\r\nX-Injected-' + key + ': yes'
+                    }
+                },
+                text: 'body'
+            });
+
+            // the injected marker must not appear at the start of its own header line
+            assert.ok(!new RegExp('\\r\\nX-Injected-' + key + ': yes').test(raw), 'CRLF injected a standalone header for list.' + key);
+            // and the (sanitized) comment text is still carried inside the List-* header
+            assert.ok(new RegExp('^List-' + key + ':', 'im').test(raw));
+        });
+    });
+
+    it('should keep a benign comment intact in the List-* header', async () => {
+        const raw = await send({
+            from: 'sender@example.test',
+            to: 'recipient@example.test',
+            subject: 'benign',
+            list: { unsubscribe: { url: 'https://example.test/u', comment: 'Unsubscribe here' } },
+            text: 'body'
+        });
+
+        const line = raw.split('\r\n').find(l => /^List-Unsubscribe:/.test(l));
+        assert.ok(line);
+        assert.ok(line.includes('(Unsubscribe here)'));
+    });
+});


### PR DESCRIPTION
Fixes the two unfixed pending security advisories. Both were reproduced against the current tree and now have regression tests; the third pending advisory (GHSA-r7g4-qg5f-qqm2, OAuth2 TLS) was already fixed in 8.0.8 by #1818 and is not part of this PR.

## GHSA-wqvq-jvpq-h66f — jsonTransport bypasses `disableFileAccess` / `disableUrlAccess`

`shared.resolveContent()` read local files and fetched URLs without consulting the access flags. `mime-node` enforces them on the streaming path, but `jsonTransport` (`mail.normalize` → `resolveAll`) and the `attachDataUrls` pre-plugin (`_convertDataImages`) resolve content *before* streaming and bypassed the policy — letting an attacker who controls a message field (attachment `path`, `text.href`, …) read local files into the JSON output or force outbound HTTP requests despite the flags being set.

`resolveContent()` now takes an optional access-policy object (the legacy `(data, key, callback)` signature is preserved) and rejects blocked content with `EFILEACCESS` / `EURLACCESS`, matching `mime-node`. `resolveAll()` and `_convertDataImages()` pass the message flags through. **No behavior change when the flags are unset.**

## GHSA-268h-hp4c-crq3 — CRLF injection in `List-*` header comments

`_getListHeaders()` inserted `list.*.comment` into prepared `List-*` headers without neutralizing CR/LF. `mimeFuncs.isPlainText()` does not treat CR/LF as disallowed, so a comment passed the plain-text check and was emitted verbatim via `foldLines()`, skipping the CRLF normalization ordinary header values get in `_encodeHeaderValue()`. An attacker influencing any `list.*.comment` field (`help`, `unsubscribe`, `subscribe`, `post`, `owner`, `archive`, `id`) could inject arbitrary headers.

CR/LF in the comment are now collapsed to a space before the prepared header is built, matching the existing normalization convention. The `url` field was already sanitized by `_formatListUrl()`.

## Tests

- `test/json-transport/json-transport-test.js`: `EFILEACCESS`/`EURLACCESS` for file & URL content under the flags, the `attachDataUrls` variant, and negative controls confirming default resolution still works.
- `test/nodemailer/list-headers-test.js`: CRLF injection blocked across all seven list comment fields, plus a benign-comment control.

`npm test` (515 pass), `npm run lint`, `npm run format:check`, and `npm run test:syntax` (Node 6) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)