### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,16 +41,10 @@ When reporting, please include as much of the following as you can:
 - A minimal proof of concept or reproduction steps.
 - Any suggested remediation, if you have one.
 
-## What to Expect
-
-- **Acknowledgement:** we aim to confirm receipt within 5 business days.
-- **Assessment:** we will investigate and let you know whether the report is
-  accepted, needs more information, or is declined (with reasoning).
-- **Fix and disclosure:** for accepted reports we will prepare a fix, publish a
-  new release, and coordinate a GitHub Security Advisory / CVE. We are happy to
-  credit reporters who wish to be named.
-- **Updates:** we will keep you informed of progress as the fix moves toward
-  release.
+Nodemailer is maintained by a single person, so there is no guaranteed response
+time — sometimes reports are handled within hours, sometimes they take longer.
+Accepted issues are fixed in a new release and coordinated through a GitHub
+Security Advisory / CVE, and reporters who wish to be named are credited.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+Nodemailer is a widely deployed, zero-dependency e-mail library. We take security
+reports seriously and aim to respond quickly.
+
+## Supported Versions
+
+Security fixes are released only against the latest major version. We do not
+backport patches to older majors — upgrading to the current release line is the
+supported way to receive security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 8.x     | :white_check_mark: |
+| < 8.0   | :x:                |
+
+If you are on an older major, please upgrade. See the migration notes at
+<https://nodemailer.com/> before updating.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Report privately through one of the following channels:
+
+1. **GitHub Security Advisories (preferred).** Open a private report at
+   <https://github.com/nodemailer/nodemailer/security/advisories/new>. This keeps
+   the discussion private until a fix is published and lets us coordinate a CVE
+   and credit you.
+2. **Email.** Send details to **andris@reinman.eu** (the contact listed in
+   [`SECURITY.txt`](SECURITY.txt)). Encrypt sensitive details if possible.
+
+When reporting, please include as much of the following as you can:
+
+- The affected version(s) and environment (Node.js version, OS).
+- The component involved (e.g. SMTP connection, address parsing, MIME/header
+  generation, DKIM).
+- A clear description of the issue and its impact (e.g. header/SMTP command
+  injection, information disclosure, DoS).
+- A minimal proof of concept or reproduction steps.
+- Any suggested remediation, if you have one.
+
+## What to Expect
+
+- **Acknowledgement:** we aim to confirm receipt within 5 business days.
+- **Assessment:** we will investigate and let you know whether the report is
+  accepted, needs more information, or is declined (with reasoning).
+- **Fix and disclosure:** for accepted reports we will prepare a fix, publish a
+  new release, and coordinate a GitHub Security Advisory / CVE. We are happy to
+  credit reporters who wish to be named.
+- **Updates:** we will keep you informed of progress as the fix moves toward
+  release.
+
+## Scope
+
+In scope: the `nodemailer` package source in this repository — message and MIME
+generation, SMTP/LMTP client behaviour, address parsing, header handling, DKIM
+signing, and the bundled transports.
+
+Out of scope: vulnerabilities in your own application code, misconfiguration of
+your mail server or credentials, social-engineering reports, and issues in
+third-party services Nodemailer connects to.
+
+Thank you for helping keep Nodemailer and its users safe.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` security policy for the repository, adapted to nodemailer rather than GitHub's generic template.

- **Supported versions:** latest major only (`8.x`), reflecting that release-please cuts releases directly from `master` with no backporting.
- **Reporting:** private disclosure via GitHub Security Advisories (preferred) or the contact in `SECURITY.txt` (andris@reinman.eu) — single contact across both files.
- **Expectations:** acknowledgement / assessment / fix-and-disclosure flow, including GHSA + CVE coordination and reporter credit (matches existing practice in CHANGELOG.md).
- **Scope:** calls out the security-sensitive components (SMTP client, address parsing, header/MIME generation, DKIM); excludes app-level misconfig.

`SECURITY.txt` (PGP-signed RFC 9116 file) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
