### PR TITLE
fix: prevent SES transport callback double-invocation and hang on sync errors

### DIFF
--- a/lib/ses-transport/index.js
+++ b/lib/ses-transport/index.js
@@ -43,11 +43,12 @@ class SESTransport extends EventEmitter {
 
     getRegion(cb) {
         if (this.ses.sesClient.config && typeof this.ses.sesClient.config.region === 'function') {
-            // promise
-            return this.ses.sesClient.config
-                .region()
-                .then(region => cb(null, region))
-                .catch(err => cb(err));
+            // Resolve the region provider. Use the two-argument form of then() so that a
+            // synchronous throw from cb is not recaught here and used to invoke cb a second time.
+            return this.ses.sesClient.config.region().then(
+                region => cb(null, region),
+                err => cb(err)
+            );
         }
         return cb(null, false);
     }
@@ -150,8 +151,27 @@ class SESTransport extends EventEmitter {
                         region = 'us-east-1';
                     }
 
-                    const command = new this.ses.SendEmailCommand(sesMessage);
-                    const sendPromise = this.ses.sesClient.send(command);
+                    let sendPromise;
+                    try {
+                        // command construction or dispatch can throw synchronously on a
+                        // misconfigured SDK; surface it as a single error callback instead
+                        // of letting it escape into getRegion's promise chain
+                        const command = new this.ses.SendEmailCommand(sesMessage);
+                        sendPromise = this.ses.sesClient.send(command);
+                    } catch (err) {
+                        tagSesError(err);
+                        this.logger.error(
+                            {
+                                err,
+                                tnx: 'send'
+                            },
+                            'Send error for %s: %s',
+                            messageId,
+                            err.message
+                        );
+                        setImmediate(() => callback(err));
+                        return;
+                    }
 
                     sendPromise
                         .then(data => {
@@ -159,7 +179,7 @@ class SESTransport extends EventEmitter {
                                 region = 'email';
                             }
 
-                            callback(null, {
+                            const info = {
                                 envelope: {
                                     from: envelope.from,
                                     to: envelope.to
@@ -167,7 +187,11 @@ class SESTransport extends EventEmitter {
                                 messageId: '<' + data.MessageId + (!/@/.test(data.MessageId) ? '@' + region + '.amazonses.com' : '') + '>',
                                 response: data.MessageId,
                                 raw
-                            });
+                            };
+
+                            // invoke the callback outside the promise chain so a throw from it
+                            // is not recaught by .catch() and used to call it a second time
+                            setImmediate(() => callback(null, info));
                         })
                         .catch(err => {
                             tagSesError(err);
@@ -180,7 +204,7 @@ class SESTransport extends EventEmitter {
                                 messageId,
                                 err.message
                             );
-                            callback(err);
+                            setImmediate(() => callback(err));
                         });
                 });
             })
@@ -222,10 +246,16 @@ class SESTransport extends EventEmitter {
         // the region value is not used for anything when verifying, but the lookup
         // exercises the client configuration the same way as send() does
         this.getRegion(() => {
-            const command = new this.ses.SendEmailCommand(sesMessage);
-            const sendPromise = this.ses.sesClient.send(command);
+            let sendPromise;
+            try {
+                const command = new this.ses.SendEmailCommand(sesMessage);
+                sendPromise = this.ses.sesClient.send(command);
+            } catch (err) {
+                setImmediate(() => cb(err));
+                return;
+            }
 
-            sendPromise.then(() => cb(null)).catch(err => cb(err));
+            sendPromise.then(() => setImmediate(() => cb(null))).catch(err => setImmediate(() => cb(err)));
         });
 
         return promise;

--- a/test/ses-transport/ses-transport-test.js
+++ b/test/ses-transport/ses-transport-test.js
@@ -5,6 +5,7 @@
 const nodemailer = require('../../lib/nodemailer');
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 
 const privateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIBywIBAAJhANCx7ncKUfQ8wBUYmMqq6ky8rBB0NL8knBf3+uA7q/CSxpX6sQ8N
@@ -214,6 +215,130 @@ describe('SES Transport Tests', { timeout: 90 * 1000 }, () => {
                 done();
             }
         );
+    });
+
+    it('should surface a synchronous SendEmailCommand failure as a single error callback', (t, done) => {
+        let transport = nodemailer.createTransport({
+            SES: {
+                sesClient: {
+                    config: {
+                        region() {
+                            return Promise.resolve('eu-west-1');
+                        }
+                    },
+                    send() {
+                        return Promise.resolve({ MessageId: 'unused' });
+                    }
+                },
+                SendEmailCommand: class {
+                    constructor() {
+                        throw new Error('ctor boom');
+                    }
+                }
+            }
+        });
+
+        let calls = 0;
+        transport.sendMail({ from: 'a@example.com', to: 'b@example.com', subject: 'test', text: 'test' }, err => {
+            calls++;
+            assert.ok(err);
+            assert.strictEqual(err.message, 'ctor boom');
+            assert.strictEqual(err.code, 'ESES');
+            // a sync throw must not hang and must not invoke the callback twice
+            setTimeout(() => {
+                assert.strictEqual(calls, 1);
+                done();
+            }, 50);
+        });
+    });
+
+    it('should surface a synchronous sesClient.send failure as a single error callback', (t, done) => {
+        let transport = nodemailer.createTransport({
+            SES: {
+                sesClient: {
+                    config: {
+                        region() {
+                            return Promise.resolve('eu-west-1');
+                        }
+                    },
+                    send() {
+                        throw new Error('send boom');
+                    }
+                },
+                SendEmailCommand
+            }
+        });
+
+        let calls = 0;
+        transport.sendMail({ from: 'a@example.com', to: 'b@example.com', subject: 'test', text: 'test' }, err => {
+            calls++;
+            assert.ok(err);
+            assert.strictEqual(err.message, 'send boom');
+            setTimeout(() => {
+                assert.strictEqual(calls, 1);
+                done();
+            }, 50);
+        });
+    });
+
+    it('should not hang verify when SendEmailCommand throws synchronously', (t, done) => {
+        let transport = nodemailer.createTransport({
+            SES: {
+                sesClient: {
+                    config: {
+                        region() {
+                            return Promise.resolve('eu-west-1');
+                        }
+                    },
+                    send() {
+                        return Promise.resolve({});
+                    }
+                },
+                SendEmailCommand: class {
+                    constructor() {
+                        throw new Error('verify ctor boom');
+                    }
+                }
+            }
+        });
+
+        transport.verify().then(
+            () => done(new Error('verify should have rejected')),
+            err => {
+                assert.strictEqual(err.message, 'verify ctor boom');
+                assert.strictEqual(err.code, 'ESES');
+                done();
+            }
+        );
+    });
+
+    it('should not re-invoke the send callback when it throws (no recatch)', () => {
+        // The callback runs detached (setImmediate) after the fix, so a throw from it surfaces
+        // as an uncaught exception rather than being recaught by .catch() and used to call the
+        // callback a second time. node:test fails a test on any uncaught exception, so this runs
+        // in a child process that absorbs the throw and reports the invocation count.
+        const entry = require.resolve('../../lib/nodemailer');
+        const script = [
+            "'use strict';",
+            'process.on("uncaughtException", () => {});',
+            `const nm = require(${JSON.stringify(entry)});`,
+            'const transport = nm.createTransport({ logger: false, SES: {',
+            '  sesClient: { config: { region() { return Promise.resolve("eu-west-1"); } },',
+            '    send() { return new Promise(r => setImmediate(() => r({ MessageId: "x" }))); } },',
+            '  SendEmailCommand: class { constructor(d) { this.d = d; } } } });',
+            'let calls = 0, secondErr = false;',
+            'transport.sendMail({ from: "a@example.com", to: "b@example.com", subject: "s", text: "t" }, err => {',
+            '  calls++; if (calls >= 2 && err) { secondErr = true; }',
+            '  if (calls === 1) { throw new Error("throw on first"); } });',
+            'setTimeout(() => { process.stdout.write("RESULT:" + JSON.stringify({ calls, secondErr })); process.exit(0); }, 100);'
+        ].join('\n');
+
+        const out = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+        const m = out.match(/RESULT:(\{.*\})/);
+        assert.ok(m, 'child did not emit a result: ' + out);
+        const res = JSON.parse(m[1]);
+        assert.strictEqual(res.calls, 1);
+        assert.strictEqual(res.secondErr, false);
     });
 
     it('should sign message with DKIM, using AWS SES JavaScript SDK v2', (t, done) => {


### PR DESCRIPTION
## Problem

Two callback-contract bugs in the SES transport, both from invoking the user callback / send-dispatch work *inside* the SDK promise chain:

1. **Double callback** — `send()` used `sendPromise.then(…callback…).catch(…callback…)`, so a throw from the callback was recaught by `.catch()` and the callback ran a second time with the error (tagged `ESES`). Affects the callback API.
2. **Hang + unhandled rejection** — `new SendEmailCommand()` / `sesClient.send()` executed inside `getRegion()`'s own `.then()`; a synchronous throw (e.g. a misconfigured SDK) landed in `getRegion`'s `.catch`, which re-invoked the worker → threw again → unhandled rejection, and the callback never fired (permanent hang). Same shape in `verify()`.

## Fix (`lib/ses-transport/index.js`)

- `send()` / `verify()`: wrap command construction + dispatch in `try/catch` → a synchronous failure surfaces as a single error callback.
- `send()` / `verify()`: invoke the callback via `setImmediate` → a throw from it can't be recaught and used to call it again.
- `getRegion()`: two-arg `.then(onF, onR)` so a throwing consumer is never re-invoked.

## Verification

- 4 new regression tests: sync `SendEmailCommand` throw, sync `sesClient.send` throw, `verify()` no-hang, and a child-process test asserting no double-invocation when the callback throws (`node --test` fails on any uncaught exception, so it can't run in-process).
- Full suite **596/596**, lint, Prettier, and the Node 6 syntax check all pass.
- Before → after: throwing callback **2×→1×**; sync dispatch throw **hang→clean single error**, unhandled rejections **1→0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)