### PR TITLE
fix: harden smtp-connection (response parsing, REQUIRETLS, DNS-close leak, proxy injection)

### DIFF
--- a/lib/smtp-connection/http-proxy-client.js
+++ b/lib/smtp-connection/http-proxy-client.js
@@ -29,6 +29,16 @@ function httpProxyClient(proxyUrl, destinationPort, destinationHost, tlsOptions,
     }
     tlsOptions = tlsOptions || {};
 
+    // Reject CRLF in the destination before it reaches the CONNECT request line
+    // and Host header. A tainted host/port could otherwise inject additional
+    // request headers into the proxy connection (HTTP request splitting).
+    destinationPort = Number(destinationPort) || 0;
+    if (!destinationPort || /[\r\n]/.test(destinationHost)) {
+        const err = new Error('Invalid proxy destination');
+        err.code = errors.EPROXY;
+        return setImmediate(() => callback(err));
+    }
+
     const proxy = urllib.parse(proxyUrl);
 
     const connectOptions = {

--- a/lib/smtp-connection/index.js
+++ b/lib/smtp-connection/index.js
@@ -365,6 +365,14 @@ class SMTPConnection extends EventEmitter {
      * @param {Boolean} secure Whether to use TLS
      */
     _connectToHost(opts, secure) {
+        // If the client was closed while DNS resolution was in flight, do not open
+        // a socket here: close() ran with this._socket still unset and so had
+        // nothing to tear down, and _onConnect's remedial close() is a no-op once
+        // _closing is set — the freshly connected socket would leak.
+        if (this._destroyed || this._closing) {
+            return;
+        }
+
         this._connectionAttemptId++;
         const currentAttemptId = this._connectionAttemptId;
 
@@ -1072,7 +1080,16 @@ class SMTPConnection extends EventEmitter {
             return false;
         }
 
-        let str = (this.lastServerResponse = decodeServerResponse((this._responseQueue.shift() || '').toString()));
+        const raw = (this._responseQueue.shift() || '').toString();
+
+        // Skip unexpected empty lines without consuming a response action or
+        // overwriting lastServerResponse; reprocess whatever else is queued.
+        if (!raw.trim()) {
+            setImmediate(() => this._processResponse());
+            return;
+        }
+
+        let str = (this.lastServerResponse = decodeServerResponse(raw));
 
         if (/^\d+-/.test(str.split('\n').pop())) {
             // keep waiting for the final part of multiline response
@@ -1086,11 +1103,6 @@ class SMTPConnection extends EventEmitter {
                 },
                 str.replace(/\r?\n$/, '')
             );
-        }
-
-        if (!str.trim()) {
-            // skip unexpected empty lines
-            setImmediate(() => this._processResponse());
         }
 
         const action = this._responseActions.shift();
@@ -1189,6 +1201,23 @@ class SMTPConnection extends EventEmitter {
             }
         }
 
+        // RFC 8689: validate REQUIRETLS eligibility before queuing the MAIL FROM
+        // response action, so a rejection here cannot leave an orphaned action in
+        // _responseActions (which would consume the next reply and desync a reused
+        // connection).
+        if (this._envelope.requireTLSExtensionEnabled) {
+            if (!this.secure) {
+                return callback(
+                    this._formatError('REQUIRETLS can only be used over TLS connections (RFC 8689)', 'EREQUIRETLS', false, 'MAIL FROM')
+                );
+            }
+            if (!this._supportedExtensions.includes('REQUIRETLS')) {
+                return callback(
+                    this._formatError('Server does not support REQUIRETLS extension (RFC 8689)', 'EREQUIRETLS', false, 'MAIL FROM')
+                );
+            }
+        }
+
         this._responseActions.push(str => {
             this._actionMAIL(str, callback);
         });
@@ -1225,20 +1254,10 @@ class SMTPConnection extends EventEmitter {
             }
         }
 
-        // RFC 8689: If the envelope requests REQUIRETLS extension
-        // then append REQUIRETLS keyword to the MAIL FROM command
-        // Note: REQUIRETLS can only be used over TLS connections and requires server support
+        // RFC 8689: append the REQUIRETLS keyword to MAIL FROM. Eligibility
+        // (TLS connection + server support) was already validated above, before
+        // the response action was queued.
         if (this._envelope.requireTLSExtensionEnabled) {
-            if (!this.secure) {
-                return callback(
-                    this._formatError('REQUIRETLS can only be used over TLS connections (RFC 8689)', 'EREQUIRETLS', false, 'MAIL FROM')
-                );
-            }
-            if (!this._supportedExtensions.includes('REQUIRETLS')) {
-                return callback(
-                    this._formatError('Server does not support REQUIRETLS extension (RFC 8689)', 'EREQUIRETLS', false, 'MAIL FROM')
-                );
-            }
             args.push('REQUIRETLS');
         }
 

--- a/test/smtp-connection/http-proxy-client-test.js
+++ b/test/smtp-connection/http-proxy-client-test.js
@@ -210,4 +210,22 @@ describe('HTTP Proxy Client Tests', { timeout: 10 * 1000 }, () => {
             });
         });
     });
+
+    it('should reject a destination host containing CRLF (request smuggling)', (t, done) => {
+        httpProxyClient('http://127.0.0.1:9/', 25, 'target.example.com\r\nX-Injected: smuggled', {}, (err, socket) => {
+            assert.ok(err);
+            assert.strictEqual(err.code, 'EPROXY');
+            assert.ok(!socket);
+            done();
+        });
+    });
+
+    it('should reject a destination port containing CRLF', (t, done) => {
+        httpProxyClient('http://127.0.0.1:9/', '25\r\nX-Injected: 1', 'mail.example.com', {}, (err, socket) => {
+            assert.ok(err);
+            assert.strictEqual(err.code, 'EPROXY');
+            assert.ok(!socket);
+            done();
+        });
+    });
 });

--- a/test/smtp-connection/requiretls-test.js
+++ b/test/smtp-connection/requiretls-test.js
@@ -316,4 +316,29 @@ describe('RFC 8689 REQUIRETLS Tests', () => {
             client.on('end', done);
         });
     });
+
+    describe('REQUIRETLS response-action discipline', () => {
+        it('does not queue a MAIL FROM response action when REQUIRETLS validation fails', () => {
+            // Non-TLS connection: REQUIRETLS requires TLS, so validation must fail
+            const conn1 = new SMTPConnection({ logger: false });
+            conn1.secure = false;
+            let err1;
+            conn1._setEnvelope({ from: 'a@example.com', to: ['b@example.com'], requireTLSExtensionEnabled: true }, e => {
+                err1 = e;
+            });
+            assert.strictEqual(err1 && err1.code, 'EREQUIRETLS');
+            assert.strictEqual(conn1._responseActions.length, 0, 'no orphaned MAIL FROM response action');
+
+            // TLS connection, but the server never advertised REQUIRETLS
+            const conn2 = new SMTPConnection({ logger: false });
+            conn2.secure = true;
+            conn2._supportedExtensions = [];
+            let err2;
+            conn2._setEnvelope({ from: 'a@example.com', to: ['b@example.com'], requireTLSExtensionEnabled: true }, e => {
+                err2 = e;
+            });
+            assert.strictEqual(err2 && err2.code, 'EREQUIRETLS');
+            assert.strictEqual(conn2._responseActions.length, 0, 'no orphaned MAIL FROM response action');
+        });
+    });
 });

--- a/test/smtp-connection/smtp-connection-test.js
+++ b/test/smtp-connection/smtp-connection-test.js
@@ -7,6 +7,7 @@ const { describe, it, before, after, beforeEach, afterEach } = require('node:tes
 const assert = require('node:assert/strict');
 const net = require('node:net');
 const SMTPConnection = require('../../lib/smtp-connection');
+const shared = require('../../lib/shared');
 const packageData = require('../../package.json');
 const SMTPServer = require('smtp-server').SMTPServer;
 const HttpConnectProxy = require('proxy-test-server');
@@ -120,6 +121,85 @@ describe('SMTP-Connection Tests', () => {
             return fn(...args);
         };
     }
+
+    describe('Response parser robustness', () => {
+        it('skips a stray empty line before the greeting and still connects', (t, done) => {
+            startServer({ greeting: '\r\n220 test ESMTP\r\n', ehlo: '250 OK\r\n' }, server => {
+                let client = makeClient(server);
+                let finish = once(failMsg =>
+                    safeDone(server, done, () => {
+                        if (failMsg) {
+                            assert.fail(failMsg);
+                        }
+                    })
+                );
+                client.on('error', err => finish('stray empty line before greeting must not error: ' + err.message));
+                client.connect(() => finish(null));
+            });
+        });
+
+        it('does not error on a stray empty line after the final EHLO response', (t, done) => {
+            startServer({ ehlo: '250-test\r\n250 PIPELINING\r\n\r\n' }, server => {
+                let client = makeClient(server);
+                let errored = null;
+                client.on('error', err => {
+                    errored = err;
+                });
+                client.connect(() => {
+                    // let the trailing empty line be (mis)processed before asserting
+                    setTimeout(() => {
+                        safeDone(server, done, () =>
+                            assert.ok(!errored, 'trailing empty line must not error: ' + (errored && errored.message))
+                        );
+                    }, 80);
+                });
+            });
+        });
+    });
+
+    describe('close() during DNS resolution', () => {
+        it('does not open a socket when closed while DNS is in flight', (t, done) => {
+            const origResolve = shared.resolveHostname;
+            let connectionsAccepted = 0;
+            let server = net.createServer(socket => {
+                connectionsAccepted++;
+                socket.write('220 test\r\n');
+            });
+            server.listen(0, '127.0.0.1', () => {
+                const port = server.address().port;
+                let deferred = null;
+                // Defer DNS resolution so we control the window in which close() lands
+                shared.resolveHostname = (opts, cb) => {
+                    deferred = () =>
+                        cb(null, { host: '127.0.0.1', servername: opts.host, _addresses: ['127.0.0.1'], port: opts.port, cached: false });
+                };
+
+                let client = new SMTPConnection({ host: 'deferred.invalid', port, ignoreTLS: true, logger: false });
+                client.on('error', () => {});
+                client.connect();
+                client.close();
+                shared.resolveHostname = origResolve; // restore immediately, before any other test runs
+
+                setImmediate(() => {
+                    if (deferred) {
+                        deferred();
+                    }
+                    setTimeout(() => {
+                        server.close(() => {
+                            let assertErr = null;
+                            try {
+                                assert.strictEqual(connectionsAccepted, 0, 'no socket should be opened after close()');
+                                assert.ok(!(client._socket && client._socket.destroyed === false), 'no live client socket should leak');
+                            } catch (e) {
+                                assertErr = e;
+                            }
+                            done(assertErr);
+                        });
+                    }, 80);
+                });
+            });
+        });
+    });
 
     describe('Version test', () => {
         it('Should expose version number', () => {


### PR DESCRIPTION
Four verified fixes from a deep review of `lib/smtp-connection`. Each was reproduced with a probe before the fix and is covered by a regression test. Full suite **602/602**, lint, Prettier, and the Node 6 syntax check all pass.

## Fixes

**1. Empty-line response desync** (`index.js` `_processResponse`)
The "skip unexpected empty lines" branch was missing a `return`, so a stray blank server line (leading, standalone, or trailing like `250 OK\r\n\r\n`) consumed the next queued response action — the action received `""` instead of the real reply, and/or a spurious `EPROTOCOL "Unexpected Response"` tore the connection down. Now skipped without consuming an action.

**2. REQUIRETLS orphaned response action** (`index.js` `_setEnvelope`)
REQUIRETLS eligibility was validated *after* the `_actionMAIL` handler was pushed onto `_responseActions` (every other validation returns before the push). A REQUIRETLS rejection left that action dangling, consuming the reply to the next command and desyncing a reused connection. Validation moved before the push.

**3. Socket leak on `close()`-during-DNS race** (`index.js` `_connectToHost`)
If `close()` ran while DNS resolution was in flight (`_socket` still unset, nothing to tear down), the resolved callback then opened a real socket that was never destroyed — `_onConnect`'s remedial `close()` is a no-op once `_closing` is set. Now `_connectToHost` bails out if the client was already closed.

**4. Proxy CONNECT CRLF injection** (`http-proxy-client.js`)
`destinationHost`/`destinationPort` were written into the CONNECT request line and Host header unsanitized; a CRLF could inject extra headers into the proxy request (HTTP request splitting). The port is now coerced to a number and a CRLF host is rejected at the boundary.

## Commits
- `fix: harden smtp-connection response parsing and socket lifecycle` — fixes 1–3 (+ tests)
- `fix: reject CRLF in HTTP proxy CONNECT destination to prevent request injection` — fix 4 (+ tests)

Lower-severity items from the review (listener hygiene in the secure-upgrade path, fallback `TEARDOWN_NOOP`, `reset()` destroyed-guard, vestigial public `destroyed` flag) are intentionally left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)