### PR TITLE
fix(mime-node): escape backslash and quote in Content-Type name parameter

### DIFF
--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -571,8 +571,10 @@ class MimeNode {
                         param = this._encodeWords(this.filename);
 
                         if (param !== this.filename || /[\s'"\\;:/=(),<>@[\]?]|^-/.test(param)) {
-                            // include value in quotes if needed
-                            param = '"' + param + '"';
+                            // include value in quotes if needed, escaping any backslash or
+                            // double quote as quoted-pairs so the quoted-string stays valid
+                            // (a trailing backslash would otherwise escape the closing quote)
+                            param = '"' + param.replace(/["\\]/g, '\\$&') + '"';
                         }
                         value += '; name=' + param;
                     }

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -672,6 +672,41 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             });
         });
 
+        it('should escape backslash and quote in Content-Type name parameter', (t, done) => {
+            // a single trailing backslash must be emitted as a quoted-pair, otherwise
+            // it escapes the closing quote and produces an unterminated quoted-string
+            // that a lenient MIME parser can use to swallow the following headers
+            let bs = String.fromCharCode(0x5c); // backslash
+            let mb = new MimeNode('application/octet-stream', {
+                filename: 'foo' + bs
+            }).setContent('x');
+
+            mb.build((err, msg) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                // name= must match the (correct) filename= form: both fully escaped
+                assert.ok(msg.indexOf('name="foo' + bs + bs + '"') >= 0);
+                assert.ok(msg.indexOf('filename="foo' + bs + bs + '"') >= 0);
+                // the broken, unterminated form must NOT be present
+                assert.strictEqual(msg.indexOf('name="foo' + bs + '"') >= 0, false);
+                done();
+            });
+        });
+
+        it('should escape backslash inside a Content-Type name parameter', (t, done) => {
+            let bs = String.fromCharCode(0x5c); // backslash
+            let mb = new MimeNode('application/octet-stream', {
+                filename: 'a' + bs + 'b.dat'
+            }).setContent('x');
+
+            mb.build((err, msg) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                assert.ok(msg.indexOf('name="a' + bs + bs + 'b.dat"') >= 0);
+                done();
+            });
+        });
+
         it('should detect content type from filename', (t, done) => {
             let mb = new MimeNode(false, {
                 filename: 'jogeva.zip'


### PR DESCRIPTION
## Summary

The `name` parameter of the `Content-Type` header is wrapped in a quoted-string without escaping `\` or `"`, unlike the `Content-Disposition` `filename` parameter built on the same node (which goes through `buildHeaderValue` → `JSON.stringify` and is escaped correctly).

An attachment whose filename ends in a backslash produces an **unterminated quoted-string**, because the trailing backslash escapes the closing quote:

```
Content-Type: application/octet-stream; name="foo\"      ← broken (unterminated)
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="foo\\"        ← correct
```

A lenient MIME parser continues consuming past the line boundary until it finds the next `"`, merging or hiding the following headers (`Content-Transfer-Encoding`, `Content-Disposition`) — i.e. header/parameter smuggling. A backslash elsewhere in the name (e.g. `a\b.txt`) is also read as a quoted-pair by a conforming parser, silently corrupting the received filename.

## Reproduction

```js
const MailComposer = require('nodemailer/lib/mail-composer');

new MailComposer({
  from: 'a@b.com',
  to: 'c@d.com',
  text: 'hi',
  attachments: [{ filename: 'foo\\', content: 'x' }]
})
  .compile()
  .build((err, msg) => console.log(msg.toString()));

// Content-Type: application/octet-stream; name="foo\"   <-- unterminated quoted-string
```

## Fix

Escape `\` and `"` as quoted-pairs before wrapping the `name` value in quotes, matching what the `Content-Disposition` path already does:

```js
param = '"' + param.replace(/["\\]/g, '\\$&') + '"';
```

The change is a no-op for the existing non-ASCII (RFC 2047 encoded-word) path, since encoded words contain no `\` or `"`.

## Tests

Adds two regression tests in `test/mime-node/mime-node-test.js` asserting the `name=` parameter is emitted with the same escaping as `filename=`. Both fail without the fix and pass with it.

- [x] `npm run lint` — clean
- [x] `npm run format:check` — changed files clean
- [x] `npm test` — full suite passing (615 tests)
