### PR TITLE
fix(mime-funcs): don't split non-emoji surrogate pairs across base64 mime words

### DIFF
--- a/lib/mime-funcs/index.js
+++ b/lib/mime-funcs/index.js
@@ -80,8 +80,8 @@ module.exports = {
                 for (let i = 0, len = encodedStr.length; i < len; i++) {
                     let chr = encodedStr.charAt(i);
 
-                    if (/[\ud83c\ud83d\ud83e]/.test(chr) && i < len - 1) {
-                        // composite emoji byte, so add the next byte as well
+                    if (/[\ud800-\udbff]/.test(chr) && i < len - 1) {
+                        // leading surrogate, so add the trailing surrogate as well
                         chr += encodedStr.charAt(++i);
                     }
 

--- a/test/mime-funcs/mime-funcs-test.js
+++ b/test/mime-funcs/mime-funcs-test.js
@@ -77,6 +77,14 @@ describe('Mime-Funcs Tests', () => {
             assert.strictEqual(outputStr, encoded);
             assert.strictEqual(inputStr, libmime.decodeWords(encoded));
         });
+
+        it('should not split a non-emoji surrogate pair when chunking base64', () => {
+            // U+20000 (CJK Extension B) uses a high surrogate outside the emoji range
+            let inputStr = '一' + '\u{20000}'.repeat(7),
+                encoded = mimeFuncs.encodeWord(inputStr, 'B', 52);
+
+            assert.strictEqual(inputStr, libmime.decodeWords(encoded));
+        });
     });
 
     describe('#buildHeaderParam', () => {


### PR DESCRIPTION
### Bug

When a mostly-non-ASCII header value is base64 mime-word encoded and long enough to be split into multiple encoded words, `encodeWord` can divide a UTF-16 surrogate pair across the chunk boundary. The high and low surrogate then get base64-encoded separately, each turning into a `U+FFFD` replacement character. RFC 2047 section 6.3 requires that "each encoded-word MUST represent an integral number of characters" — a multibyte character must never be split between two encoded words.

The chunking loop already guards against this, but only for the emoji high surrogates `U+D83C`–`U+D83E`. Any other supplementary character (CJK Extension B, historic scripts, math alphanumerics, older emoji planes, etc.) is unprotected and gets corrupted.

### Repro

```js
const mimeFuncs = require('nodemailer/lib/mime-funcs');
const libmime = require('libmime');

// one BMP CJK + seven U+20000 (CJK Ext B); B encoding, maxLength 52 (what mime-node uses)
const subject = '一' + '\u{20000}'.repeat(7);
const encoded = mimeFuncs.encodeWord(subject, 'B', 52);

console.log(encoded);
// =?UTF-8?B?...77+9?= =?UTF-8?B?77+9?=   (77+9 == base64 of ef bf bd, i.e. U+FFFD)
console.log(libmime.decodeWords(encoded) === subject); // false — last char became replacement chars
```

This is reachable from normal use: `mime-node` calls `encodeWord(value, 'B', 52)` for `Subject` and address display names whenever the text is predominantly non-latin (`_getTextEncoding` picks `B`).

### Fix

Broaden the surrogate check from the emoji-only range to the full high-surrogate range `U+D800`–`U+DBFF`, so the trailing low surrogate is always kept with its leading high surrogate and no character is divided between encoded words. Emoji already went through this path and are unaffected.

Adds a regression test that round-trips a CJK Extension B string through `encodeWord` + `libmime.decodeWords`.
