### PR TITLE
chore(services): add TurboSMTP

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -577,6 +577,20 @@
         "port": 587
     },
 
+    "TurboSMTP": {
+        "description": "TurboSMTP",
+        "host": "pro.turbo-smtp.com",
+        "port": 465,
+        "secure": true
+    },
+
+    "TurboSMTP-EU": {
+        "description": "TurboSMTP (EU region)",
+        "host": "pro.eu.turbo-smtp.com",
+        "port": 465,
+        "secure": true
+    },
+
     "Tutanota": {
         "description": "Tutanota (Tuta Mail)",
         "domains": ["tutanota.com", "tuta.com", "tutanota.de", "tuta.io"],


### PR DESCRIPTION
Adds TurboSMTP to the well-known services list, so it can be selected with `service: 'TurboSMTP'` (or `'TurboSMTP-EU'` for the EU region) instead of setting host/port/secure manually.