### PR TITLE
fix(mime): encode HT/CR/LF in header parameter values instead of quoting them

### DIFF
--- a/lib/mime-funcs/index.js
+++ b/lib/mime-funcs/index.js
@@ -10,11 +10,18 @@ module.exports = {
     /**
      * Checks if a value is plaintext string (uses only printable 7bit chars)
      *
+     * When isParam is set the value is destined for a header parameter, so HT, CR and LF
+     * are not plaintext either: a header parameter has no way to carry them. HT is a valid
+     * fold point, so folding and unfolding a header would rewrite it as a space, and CR/LF
+     * cannot appear in a header value at all. Such values have to go through the rfc2231
+     * parameter continuation encoding instead, the same way a quote already does.
+     *
      * @param {String} value String to be tested
+     * @param {Boolean} [isParam] Set to true if the value is a header parameter value
      * @returns {Boolean} true if it is a plaintext string
      */
     isPlainText(value, isParam) {
-        const re = isParam ? /[\x00-\x08\x0b\x0c\x0e-\x1f"\u0080-\uFFFF]/ : /[\x00-\x08\x0b\x0c\x0e-\x1f\u0080-\uFFFF]/;
+        const re = isParam ? /[\x00-\x1f"\u0080-\uFFFF]/ : /[\x00-\x08\x0b\x0c\x0e-\x1f\u0080-\uFFFF]/;
         return typeof value === 'string' && !re.test(value);
     },
 

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -568,7 +568,12 @@ class MimeNode {
                         // add support for non-compliant clients like QQ webmail
                         // we can't build the value with buildHeaderValue as the value is non standard and
                         // would be converted to parameter continuation encoding that we do not want
-                        param = this._encodeWords(this.filename);
+                        // control chars can not be quoted here: HT is a fold point that unfolding would
+                        // turn into a space and CR/LF can not appear in a header at all, so force the
+                        // mime encoded word that a non-ascii filename would get anyway
+                        param = /[\x00-\x1f]/.test(this.filename)
+                            ? mimeFuncs.encodeWord(this.filename, this._getTextEncoding(this.filename), 52)
+                            : this._encodeWords(this.filename);
 
                         if (param !== this.filename || /[\s'"\\;:/=(),<>@[\]?]|^-/.test(param)) {
                             // include value in quotes if needed

--- a/test/mime-funcs/mime-funcs-test.js
+++ b/test/mime-funcs/mime-funcs-test.js
@@ -20,6 +20,14 @@ describe('Mime-Funcs Tests', () => {
             assert.strictEqual(mimeFuncs.isPlainText('az09\n\x08!?'), false);
         });
 
+        it('should not treat tabs and line breaks as plaintext in a parameter value', () => {
+            // a header parameter can not carry these, unlike a header value or a body
+            assert.strictEqual(mimeFuncs.isPlainText('az09\t!?', true), false);
+            assert.strictEqual(mimeFuncs.isPlainText('az09\r!?', true), false);
+            assert.strictEqual(mimeFuncs.isPlainText('az09\n!?', true), false);
+            assert.strictEqual(mimeFuncs.isPlainText('az09!?', true), true);
+        });
+
         it('should return false on high bits', () => {
             assert.strictEqual(mimeFuncs.isPlainText('az09\nõ!?'), false);
         });
@@ -288,6 +296,24 @@ describe('Mime-Funcs Tests', () => {
                     }
                 }),
                 "test; a*0*=utf-8''%3B%22"
+            );
+            assert.strictEqual(
+                mimeFuncs.buildHeaderValue({
+                    value: 'test',
+                    params: {
+                        a: 'x\ty'
+                    }
+                }),
+                "test; a*0*=utf-8''x%09y"
+            );
+            assert.strictEqual(
+                mimeFuncs.buildHeaderValue({
+                    value: 'test',
+                    params: {
+                        a: 'x\r\ny'
+                    }
+                }),
+                "test; a*0*=utf-8''x%0D%0Ay"
             );
             assert.strictEqual(
                 mimeFuncs.buildHeaderValue({

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -657,6 +657,41 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             });
         });
 
+        it('should encode filename with a tab', (t, done) => {
+            let mb = new MimeNode('application/pdf', {
+                filename: 'in\tvoice.pdf'
+            }).setContent('jõgeva');
+
+            mb.build((err, msg) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                // the tab has to be encoded, not quoted: a quoted-pair "\t" means a literal
+                // "t" and a raw tab is a fold point that unfolding turns into a space
+                assert.strictEqual(/^Content-Disposition: attachment; filename\*0\*=utf-8''in%09voice.pdf$/m.test(msg), true);
+                assert.strictEqual(/^Content-Type: application\/pdf; name="=\?UTF-8\?Q\?in=09voice=2Epdf\?="$/m.test(msg), true);
+                // no raw control char and no bogus quoted-pair anywhere in the headers
+                const headers = msg.split('\r\n\r\n')[0];
+                assert.strictEqual(/[\x00-\x08\x0b\x0c\x0e-\x1f]|\t/.test(headers), false);
+                assert.strictEqual(/\\t/.test(headers), false);
+                done();
+            });
+        });
+
+        it('should encode filename with a line break', (t, done) => {
+            let mb = new MimeNode('application/pdf', {
+                filename: 'in\r\nvoice.pdf'
+            }).setContent('jõgeva');
+
+            mb.build((err, msg) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                assert.strictEqual(/^Content-Disposition: attachment; filename\*0\*=utf-8''in%0D%0Avoice.pdf$/m.test(msg), true);
+                const headers = msg.split('\r\n\r\n')[0];
+                assert.strictEqual(/\\r|\\n/.test(headers), false);
+                done();
+            });
+        });
+
         it('should encode filename with a space', (t, done) => {
             let mb = new MimeNode('text/plain', {
                 filename: 'document a.test.pdf'


### PR DESCRIPTION
An attachment filename containing a tab or a line break is silently corrupted in both headers that carry it — and differently in each one.

```js
const t = nodemailer.createTransport({ streamTransport: true, buffer: true });
t.sendMail({
    from: 'a@example.com', to: 'b@example.com', subject: 'x', text: 'hello',
    attachments: [{ filename: 'in\tvoice.pdf', content: 'x' }]
}, (err, info) => console.log(info.message.toString()));
```

on `master`:

```
Content-Type: application/pdf; name="in<TAB>voice.pdf"
Content-Disposition: attachment; filename="in\tvoice.pdf"
```

Feeding either header to `libmime` (already a devDependency here) gives `intvoice.pdf`, not `in\tvoice.pdf`.

## Why

**`filename=`** — `isPlainText(value, true)` treats HT, CR and LF as plaintext, so the value stays on the quoted-string path in `buildHeaderValue`, where quoting is done with `JSON.stringify`. That emits JavaScript escapes, and `\t` is not a MIME quoted-pair for a tab: per RFC 822 a quoted-pair `\X` means a literal `X`, so the tab is read back as the letter `t`. `\r` and `\n` degrade the same way, to `r` and `n`.

These three are the only control characters that reach that path — `\x00-\x08`, `\x0b`, `\x0c` and `\x0e-\x1f` are already rejected by the same predicate, which is why this only shows up for tabs and line breaks.

**`name=`** — the Content-Type fallback for non-compliant clients deliberately avoids parameter continuation encoding, so the tab is emitted raw into the quoted string instead. A raw tab there is a valid fold point, so folding and unfolding the header rewrites it as a space:

```
Content-Type: application/pdf; name="quarterly<TAB>report<TAB>for<TAB>the<TAB>board<TAB>of
	directors<TAB>final<TAB>version<TAB>two.pdf"
```
unfolds to `...board<TAB>of directors<TAB>final...` — a different filename than was passed in.

## Fix

Both now get the encoding a non-ascii filename already gets — rfc2231 percent-encoding for `filename=`, a mime encoded word for `name=`:

```
Content-Type: application/pdf; name="=?UTF-8?Q?in=09voice=2Epdf?="
Content-Disposition: attachment; filename*0*=utf-8''in%09voice.pdf
```

`libmime` now reads the filename back byte-exact.

Only the `isParam` branch of `isPlainText` changes. Header values and bodies, which can legitimately carry tabs and line breaks, go through the other branch and are unaffected — the existing `isPlainText('az09\t\r\n~!?') === true` test still passes untouched.

This is a correctness bug, not an injection one: `_encodeHeaderValue` already strips CR/LF from the finished header value, so the old behaviour mangled the filename rather than splitting the header.

## Verification

- `npm test` — 616 tests, 616 pass, 0 fail.
- `npm run lint` — clean. `npm run format:check` — only the pre-existing `lib/punycode/index.js` warning, untouched by this change.
- Cross-checked against `libmime` as an independent parser, before and after.
- Found by round-trip fuzzing `buildHeaderValue` → `parseHeaderValue` over random filenames. Across 216k generated filenames containing HT/CR/LF, `master` emitted 19,174 headers carrying a `\t`/`\n`/`\r` that no MIME parser reads as the original character; after the change, zero, and no raw control characters either.

New tests: tab and line-break filenames end to end in `test/mime-node`, the two `buildHeaderValue` parameter cases, and the `isPlainText` `isParam` contract.
