### PR TITLE
fix(mailer): escape specials in List-* header comments

### DIFF
--- a/lib/mailer/mail-message.js
+++ b/lib/mailer/mail-message.js
@@ -276,7 +276,10 @@ class MailMessage {
                                 // strip CR/LF so a comment can't inject extra header lines
                                 let comment = (value.comment || '').toString().replace(/\r?\n|\r/g, ' ');
                                 if (mimeFuncs.isPlainText(comment)) {
-                                    comment = '"' + comment + '"';
+                                    // escape quote and backslash as quoted-pairs, otherwise a quote ends the
+                                    // quoted-string early and a trailing backslash escapes the closing quote,
+                                    // which swallows the <domain> that follows it
+                                    comment = '"' + comment.replace(/["\\]/g, '\\$&') + '"';
                                 } else {
                                     comment = mimeFuncs.encodeWord(comment);
                                 }
@@ -293,6 +296,12 @@ class MailMessage {
                             let comment = (value.comment || '').toString().replace(/\r?\n|\r/g, ' ');
                             if (!mimeFuncs.isPlainText(comment)) {
                                 comment = mimeFuncs.encodeWord(comment);
+                            } else {
+                                // escape the ctext specials as quoted-pairs, otherwise a ")" closes the
+                                // comment early and leaves the rest as junk, an unpaired "(" opens a
+                                // nested comment that never closes, and a trailing backslash escapes
+                                // the closing ")" so the comment swallows whatever follows it
+                                comment = comment.replace(/[()\\]/g, '\\$&');
                             }
 
                             return this._formatListUrl(value.url) + (value.comment ? ' (' + comment + ')' : '');

--- a/test/nodemailer/list-headers-test.js
+++ b/test/nodemailer/list-headers-test.js
@@ -72,6 +72,101 @@ describe('List-* header comment CRLF injection', () => {
         });
     });
 
+    // A comment is inserted into a quoted-string (List-ID) or an RFC 5322 comment
+    // (every other List-* header), so the specials of the surrounding construct have
+    // to be emitted as quoted-pairs. Stripping CR/LF alone is not enough: without the
+    // escaping the comment ends early, never ends, or is read back as different text.
+    describe('List-* header comment escaping', () => {
+        const listIdValue = async comment => {
+            const raw = await send({
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'list id',
+                list: { id: { url: 'mylist.example.test', comment } },
+                text: 'body'
+            });
+
+            const line = raw.split('\r\n').find(l => /^List-ID:/i.test(l));
+            assert.ok(line, 'no List-ID header');
+            return line;
+        };
+
+        it('should escape a quote in a List-ID comment', async () => {
+            // an unescaped quote ends the quoted-string early, so everything after it,
+            // including the <domain>, is no longer where the grammar expects it
+            assert.strictEqual(await listIdValue('a"b'), 'List-ID: "a\\"b" <mylist.example.test>');
+        });
+
+        it('should escape a trailing backslash in a List-ID comment', async () => {
+            // a raw trailing backslash escapes the closing quote, so the quoted-string
+            // runs on and swallows the <domain> that identifies the list
+            assert.strictEqual(await listIdValue('x\\'), 'List-ID: "x\\\\" <mylist.example.test>');
+        });
+
+        it('should escape a backslash inside a List-ID comment', async () => {
+            // an unescaped backslash is a quoted-pair, so the receiver reads back "ab"
+            assert.strictEqual(await listIdValue('a\\b'), 'List-ID: "a\\\\b" <mylist.example.test>');
+        });
+
+        const listUrlValue = async comment => {
+            const raw = await send({
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'list unsubscribe',
+                list: { unsubscribe: { url: 'https://example.test/u', comment } },
+                text: 'body'
+            });
+
+            const line = raw.split('\r\n').find(l => /^List-Unsubscribe:/i.test(l));
+            assert.ok(line, 'no List-Unsubscribe header');
+            return line;
+        };
+
+        it('should escape a closing parenthesis in a List-* comment', async () => {
+            // an unescaped ")" closes the comment early and leaves the remainder as junk
+            assert.strictEqual(await listUrlValue('a)b'), 'List-Unsubscribe: <https://example.test/u> (a\\)b)');
+        });
+
+        it('should escape an opening parenthesis in a List-* comment', async () => {
+            // comments nest, so an unpaired "(" opens one that is never closed
+            assert.strictEqual(await listUrlValue('a(b'), 'List-Unsubscribe: <https://example.test/u> (a\\(b)');
+        });
+
+        it('should escape a trailing backslash in a List-* comment', async () => {
+            assert.strictEqual(await listUrlValue('x\\'), 'List-Unsubscribe: <https://example.test/u> (x\\\\)');
+        });
+
+        it('should not let a comment swallow a following url in the same header', async () => {
+            const raw = await send({
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'list unsubscribe',
+                // both entries share one header, joined with ", "
+                list: { unsubscribe: [[{ url: 'https://example.test/u', comment: 'x\\' }, { url: 'mailto:u@example.test' }]] },
+                text: 'body'
+            });
+
+            const line = raw.split('\r\n').find(l => /^List-Unsubscribe:/i.test(l));
+            // the trailing backslash used to escape the ")", leaving an unterminated
+            // comment that consumed the mailto: entry
+            assert.strictEqual(line, 'List-Unsubscribe: <https://example.test/u> (x\\\\), <mailto:u@example.test>');
+        });
+
+        it('should not escape anything in a non-plaintext comment', async () => {
+            // a non-ascii comment becomes an encoded word, which has no specials to escape
+            const raw = await send({
+                from: 'sender@example.test',
+                to: 'recipient@example.test',
+                subject: 'list unsubscribe',
+                list: { unsubscribe: { url: 'https://example.test/u', comment: 'ünsubscribe' } },
+                text: 'body'
+            });
+
+            const line = raw.split('\r\n').find(l => /^List-Unsubscribe:/i.test(l));
+            assert.strictEqual(line, 'List-Unsubscribe: <https://example.test/u> (=?UTF-8?Q?=C3=BCnsubscribe?=)');
+        });
+    });
+
     it('should keep a benign comment intact in the List-* header', async () => {
         const raw = await send({
             from: 'sender@example.test',


### PR DESCRIPTION
A `list.*.comment` value is interpolated directly into the construct that carries it, with only CR/LF stripped, so the specials of that construct are emitted raw. The comment then ends early, never ends, or is read back as different text — and in one case it swallows the URL that follows it.

This extends the CR/LF stripping from GHSA-268h-hp4c-crq3. That fix stopped a comment from injecting a *new header*; it did not stop a comment from corrupting *its own header*. It is the same escaping that #1837 added for the `Content-Type` `name=` parameter, applied to the other path that hand-builds a quoted construct.

Not a security issue: CR/LF are still stripped first, so nothing here crosses a header boundary, and the `list` key is separately CRLF-normalised. The impact is a malformed or silently altered header value.

### List-ID — quoted-string (RFC 5322 §3.2.4: `qtext` excludes `"` and `\`)

`_getListHeaders()` builds `'"' + comment + '"'`. `mimeFuncs.isPlainText(comment)` is called without `isParam`, and that variant does not reject `"`, so a quote reaches the quoted-string unescaped.

| `comment` | emitted | read back |
|---|---|---|
| `a"b` | `List-ID: "a"b" <mylist.example.test>` | parse error — the string ends at the second quote, so `<domain>` is no longer where the grammar expects it |
| `x\` | `List-ID: "x\" <mylist.example.test>` | parse error — the backslash escapes the closing quote, the string runs on and swallows the `<domain>` |
| `a\b` | `List-ID: "a\b" <mylist.example.test>` | **`ab`** — an unescaped backslash is a quoted-pair, so the comment is silently altered |

The last one is the quiet one: the header stays valid, it just no longer says what the caller asked for. Losing the `<domain>` in the other two loses the RFC 2919 list identifier, which is the entire content of the header.

### Other List-* headers — RFC 5322 comment (§3.2.2: `ctext` excludes `(`, `)`, `\`)

`return this._formatListUrl(value.url) + ' (' + comment + ')'`.

| `comment` | emitted | read back |
|---|---|---|
| `a)b` | `<https://example.test/u> (a)b)` | parse error — the comment closes at the first `)` and `b)` is junk where only CFWS or `<...>` is allowed |
| `a(b` | `<https://example.test/u> (a(b)` | parse error — comments nest, so the unpaired `(` opens one that never closes |
| `x\` | `<https://example.test/u> (x\)` | parse error — the backslash escapes the closing `)` |

The unterminated cases matter most when one header carries several entries, because `_getListHeaders()` joins them with `", "` inside a single value:

```js
list: { unsubscribe: [[{ url: 'https://example.test/u', comment: 'x\\' }, { url: 'mailto:u@example.test' }]] }
```

```
List-Unsubscribe: <https://example.test/u> (x\), <mailto:u@example.test>
```

The comment never closes, so a parser consumes `, <mailto:u@example.test>` as comment text. The `mailto:` alternative — the one that matters for one-click unsubscribe — is gone, and the surviving header is malformed.

## Fix

Emit the specials of the surrounding construct as quoted-pairs, in the plaintext branch only. A non-plaintext comment already becomes an encoded word, which contains no specials, so that path is untouched.

## Verification

`npm test` — **629 passing, 0 failing** (8 new). `npm run lint` clean. `npm run format:check` reports only the pre-existing `lib/punycode/index.js` warning, which is present on unmodified `master` and left alone.

7 of the 8 new tests fail without the `lib/` change (the 8th is the encoded-word no-change guard), so each assertion is red on the bug and green on the fix, rather than passing on both.

Beyond the unit tests, I parsed the generated headers with a strict RFC 5322 comment/quoted-string reader (nested comments, quoted-pairs) to check what a receiver actually recovers:

```
BEFORE                                          AFTER
List-ID   comment="a\"b"  -> PARSE ERROR        -> phrase="a\"b"  OK
List-ID   comment="x\\"   -> PARSE ERROR        -> phrase="x\\"   OK
List-ID   comment="a\\b"  -> phrase="ab"  <--   -> phrase="a\\b"  OK
List-Unsub comment="a)b"  -> PARSE ERROR        -> urls=[2] comments=["a)b"]  OK
List-Unsub comment="a(b"  -> PARSE ERROR        -> urls=[2] comments=["a(b"]  OK
List-Unsub comment="x\\"  -> PARSE ERROR        -> urls=[2] comments=["x\\"]  OK
List-Unsub comment="Unsubscribe here"  -> OK    -> OK   (unchanged)
```

Every comment now round-trips byte-exact and both URLs survive, while benign comments are emitted identically to before.

`npm run test:syntax` could not run here (no Docker daemon on this machine). The change adds only ES5 constructs — a regex literal and `String.prototype.replace` with `$&` — and `node test/syntax-compat.js` passes on the local runtime, so the Node 6 gate should be unaffected.

No changes to `CHANGELOG.md`, the version, or anything else release-please owns.
