### PR TITLE
docs: replace dead Node.js c-ares dependencies link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let configOptions = {
 
 #### I have issues with DNS / hosts file
 
-Node.js uses [c-ares](https://nodejs.org/en/docs/meta/topics/dependencies/#c-ares) to resolve domain names, not the DNS library provided by the system, so if you have some custom DNS routing set up, it might be ignored. Nodemailer runs [dns.resolve4()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve4hostname-options-callback) and [dns.resolve6()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve6hostname-options-callback) to resolve hostname into an IP address. If both calls fail, then Nodemailer will fall back to [dns.lookup()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnslookuphostname-options-callback). If this does not work for you, you can hard code the IP address into the configuration like shown below. In that case, Nodemailer would not perform any DNS lookups.
+Node.js uses [c-ares](https://github.com/c-ares/c-ares) to resolve domain names, not the DNS library provided by the system, so if you have some custom DNS routing set up, it might be ignored. Nodemailer runs [dns.resolve4()](https://nodejs.org/api/dns.html#dnsresolve4hostname-options-callback) and [dns.resolve6()](https://nodejs.org/api/dns.html#dnsresolve6hostname-options-callback) to resolve hostname into an IP address. If both calls fail, then Nodemailer will fall back to [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback). If this does not work for you, you can hard code the IP address into the configuration like shown below. In that case, Nodemailer would not perform any DNS lookups.
 
 ```js
 let configOptions = {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let configOptions = {
 
 #### I have issues with DNS / hosts file
 
-Node.js uses [c-ares](https://github.com/c-ares/c-ares) to resolve domain names, not the DNS library provided by the system, so if you have some custom DNS routing set up, it might be ignored. Nodemailer runs [dns.resolve4()](https://nodejs.org/api/dns.html#dnsresolve4hostname-options-callback) and [dns.resolve6()](https://nodejs.org/api/dns.html#dnsresolve6hostname-options-callback) to resolve hostname into an IP address. If both calls fail, then Nodemailer will fall back to [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback). If this does not work for you, you can hard code the IP address into the configuration like shown below. In that case, Nodemailer would not perform any DNS lookups.
+Node.js uses [c-ares](https://github.com/c-ares/c-ares) to resolve domain names, not the DNS library provided by the system, so if you have some custom DNS routing set up, it might be ignored. Nodemailer runs [dns.resolve4()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve4hostname-options-callback) and [dns.resolve6()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnsresolve6hostname-options-callback) to resolve hostname into an IP address. If both calls fail, then Nodemailer will fall back to [dns.lookup()](https://nodejs.org/dist/latest-v16.x/docs/api/dns.html#dnslookuphostname-options-callback). If this does not work for you, you can hard code the IP address into the configuration like shown below. In that case, Nodemailer would not perform any DNS lookups.
 
 ```js
 let configOptions = {


### PR DESCRIPTION
## Problem

The "I have issues with DNS / hosts file" FAQ links to a removed Node.js page:

https://nodejs.org/en/docs/meta/topics/dependencies/#c-ares

A curl -L GET of that URL returns 404.

## Solution

Point the c-ares mention at the current c-ares project page:

https://github.com/c-ares/c-ares

That is the resolver Node still uses for `dns.resolve*`. The nearby Node.js DNS API links are left unchanged because they still return 200.

## Verification

```
curl -sL -o /dev/null -w "%{http_code}\n" https://nodejs.org/en/docs/meta/topics/dependencies/#c-ares
# 404

curl -sL -o /dev/null -w "%{http_code}\n" https://github.com/c-ares/c-ares
# 200
```
