### PR TITLE
docs: mark 9.x as the supported security line

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ supported way to receive security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 8.x     | :white_check_mark: |
-| < 8.0   | :x:                |
+| 9.x     | :white_check_mark: |
+| < 9.0   | :x:                |
 
 If you are on an older major, please upgrade. See the migration notes at
 <https://nodemailer.com/> before updating.


### PR DESCRIPTION
## Problem

`SECURITY.md` still lists `8.x` as the only supported major. The current release on `master` is `9.0.5` (`package.json` and GitHub releases). The same file says security fixes ship only against the latest major.

Verified:

- `package.json` version: `9.0.5`
- Latest GitHub release tag: `v9.0.5`
- `v9.0.0` already exists on the repo
- No open or closed PR updates the supported-versions table for 9.x (the original policy landed in #1824 while 8.x was current)

## Change

Update the supported-versions table from `8.x` / `< 8.0` to `9.x` / `< 9.0`. No policy wording change.

## Test plan

- [x] Table now matches the latest major on `master`
