### PR TITLE
docs: mark 9.x as the supported security line

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ supported way to receive security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 8.x     | :white_check_mark: |
-| < 8.0   | :x:                |
+| 9.x     | :white_check_mark: |
+| < 9.0   | :x:                |
 
 If you are on an older major, please upgrade. See the migration notes at
 <https://nodemailer.com/> before updating.


### PR DESCRIPTION
## Problem

`SECURITY.md` says security fixes ship only against the latest major, then lists `8.x` as the supported line. The published package is already 9.x (`package.json` is 9.0.5; GitHub releases include v9.0.0 through v9.0.5).

The same file says older majors are not backported, so the table is now both stale and contradictory.

## Solution

Update the supported-versions table to `9.x` and mark `< 9.0` as unsupported, matching the policy text and the current release line.

## Verification

- `package.json` `version` is `9.0.5`
- Latest GitHub release tag is `v9.0.5`
- Open PR list at submission time: only the release-please 9.0.6 PR and a separate README c-ares link PR; neither touches `SECURITY.md`
