### PR TITLE
fix: harden address parsing and domain normalization

### DIFF
--- a/lib/addressparser/index.js
+++ b/lib/addressparser/index.js
@@ -184,14 +184,18 @@ function _handleAddress(tokens, depth) {
                 token.value = token.value.replace(/^[^<]*<\s*/, '');
             }
 
-            // A comment is folding whitespace. It may sit inside an addr-spec, on either
-            // side of the '@', but it cannot join two atoms into one: gluing across it
-            // would read 'user@example.com(x)evil.com' as the single domain
-            // 'example.comevil.com' and deliver to a domain the sender never named.
-            const tail = data[state].length ? data[state][data[state].length - 1] : '';
-            const joinsAcrossComment = tail.slice(-1) === '@' || token.value.charAt(0) === '@';
+            // A comment is folding whitespace. It may sit inside an addr-spec, on either side
+            // of the '@', but it cannot join two atoms into one: gluing across it would read
+            // 'user@example.com(x)evil.com' as the single domain 'example.comevil.com' and
+            // deliver to a domain the sender never named.
+            const parts = data[state];
+            const joins =
+                prevToken &&
+                prevToken.noBreak &&
+                parts.length &&
+                (prevToken.value !== ')' || parts[parts.length - 1].slice(-1) === '@' || token.value.charAt(0) === '@');
 
-            if (prevToken && prevToken.noBreak && data[state].length && (!prevToken.cfws || joinsAcrossComment)) {
+            if (joins) {
                 data[state][data[state].length - 1] += token.value;
                 if (state === 'text' && insideQuotes) {
                     data.textWasQuoted[data.textWasQuoted.length - 1] = true;
@@ -404,11 +408,6 @@ class Tokenizer {
 
             if (nextChr && ![' ', '\t', '\r', '\n', ',', ';'].includes(nextChr)) {
                 this.node.noBreak = true;
-            }
-
-            if (chr === ')') {
-                // Closing a comment, which is folding whitespace rather than content
-                this.node.cfws = true;
             }
 
             this.list.push(this.node);

--- a/lib/addressparser/index.js
+++ b/lib/addressparser/index.js
@@ -499,8 +499,10 @@ function addressparser(str, options) {
 
     addresses.forEach(addr => {
         const handled = _handleAddress(addr, depth);
-        if (handled.length) {
-            parsedAddresses = parsedAddresses.concat(handled);
+        // Appended in place. Rebuilding the accumulator with concat() would copy every
+        // entry collected so far on each address, making a flat list cost O(n^2).
+        for (let i = 0; i < handled.length; i++) {
+            parsedAddresses.push(handled[i]);
         }
     });
 
@@ -508,14 +510,20 @@ function addressparser(str, options) {
     // "Joe Foo, PhD <joe@example.com>" is split on the comma into
     // [{name:"Joe Foo", address:""}, {name:"PhD", address:"joe@example.com"}].
     // Recombine: a name-only entry followed by an entry with both name and address.
-    for (let i = parsedAddresses.length - 2; i >= 0; i--) {
+    // Walked back to front so that a run of fragments folds into one entry in a single
+    // pass. Splicing each fragment out of the list instead would cost O(n^2).
+    const mergedAddresses = [];
+    for (let i = parsedAddresses.length - 1; i >= 0; i--) {
         const current = parsedAddresses[i];
-        const next = parsedAddresses[i + 1];
-        if (current.address === '' && current.name && !current.group && next.address && next.name) {
+        const next = mergedAddresses.length ? mergedAddresses[mergedAddresses.length - 1] : null;
+        if (next && current.address === '' && current.name && !current.group && next.address && next.name) {
             next.name = current.name + ', ' + next.name;
-            parsedAddresses.splice(i, 1);
+        } else {
+            mergedAddresses.push(current);
         }
     }
+    mergedAddresses.reverse();
+    parsedAddresses = mergedAddresses;
 
     if (options.flatten) {
         const flatAddresses = [];

--- a/lib/addressparser/index.js
+++ b/lib/addressparser/index.js
@@ -184,7 +184,14 @@ function _handleAddress(tokens, depth) {
                 token.value = token.value.replace(/^[^<]*<\s*/, '');
             }
 
-            if (prevToken && prevToken.noBreak && data[state].length) {
+            // A comment is folding whitespace. It may sit inside an addr-spec, on either
+            // side of the '@', but it cannot join two atoms into one: gluing across it
+            // would read 'user@example.com(x)evil.com' as the single domain
+            // 'example.comevil.com' and deliver to a domain the sender never named.
+            const tail = data[state].length ? data[state][data[state].length - 1] : '';
+            const joinsAcrossComment = tail.slice(-1) === '@' || token.value.charAt(0) === '@';
+
+            if (prevToken && prevToken.noBreak && data[state].length && (!prevToken.cfws || joinsAcrossComment)) {
                 data[state][data[state].length - 1] += token.value;
                 if (state === 'text' && insideQuotes) {
                     data.textWasQuoted[data.textWasQuoted.length - 1] = true;
@@ -397,6 +404,11 @@ class Tokenizer {
 
             if (nextChr && ![' ', '\t', '\r', '\n', ',', ';'].includes(nextChr)) {
                 this.node.noBreak = true;
+            }
+
+            if (chr === ')') {
+                // Closing a comment, which is folding whitespace rather than content
+                this.node.cfws = true;
             }
 
             this.list.push(this.node);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,6 +38,7 @@ const ERROR_CODES = {
 
     // Resource errors
     EMAXLIMIT: 'Pool resource limit reached (max messages per connection)',
+    EMAXRECIPIENTS: 'Recipient count exceeds maxRecipients',
 
     // Transport-specific errors
     ESENDMAIL: 'Sendmail command error',

--- a/lib/mailer/index.js
+++ b/lib/mailer/index.js
@@ -16,6 +16,13 @@ const dns = require('dns');
 const crypto = require('crypto');
 
 /**
+ * Recipients allowed on one message unless the caller sets its own maxRecipients. A backstop
+ * against a runaway or hostile recipient list rather than a delivery policy: RFC 5321 only
+ * asks a server to accept 100, so a real send is bounded far below this.
+ */
+const DEFAULT_MAX_RECIPIENTS = 100000;
+
+/**
  * Creates an object for exposing the Mail API
  *
  * @constructor
@@ -190,6 +197,26 @@ class Mail extends EventEmitter {
             mail.setMailerHeader();
             mail.setPriorityHeaders();
             mail.setListHeaders();
+
+            const maxRecipients = mail.data.maxRecipients === undefined ? DEFAULT_MAX_RECIPIENTS : mail.data.maxRecipients;
+            const recipientCount = mail.message.getEnvelope().to.length;
+
+            if (maxRecipients && recipientCount > maxRecipients) {
+                const err = new Error(
+                    `Message has ${recipientCount} recipients, which is over the ${maxRecipients} allowed by maxRecipients`
+                );
+                err.code = errors.EMAXRECIPIENTS;
+                this.logger.error(
+                    {
+                        err,
+                        tnx: 'transport',
+                        action: 'send'
+                    },
+                    'Send Error: %s',
+                    err.message
+                );
+                return callback(err);
+            }
 
             this._processPlugins('stream', mail, err => {
                 if (err) {

--- a/lib/mailer/mail-message.js
+++ b/lib/mailer/mail-message.js
@@ -31,7 +31,7 @@ class MailMessage {
         shared.copyOwnKeys(this.data.headers, defaults.headers, key => hasOwn(this.data.headers, key));
 
         // force specific keys from transporter options
-        ['disableFileAccess', 'disableUrlAccess', 'normalizeHeaderKey'].forEach(key => {
+        ['disableFileAccess', 'disableUrlAccess', 'normalizeHeaderKey', 'maxRecipients'].forEach(key => {
             if (key in options) {
                 this.data[key] = options[key];
             }

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const punycode = require('../punycode');
 const { PassThrough } = require('stream');
 const shared = require('../shared');
+const urlModule = require('url');
 
 const mimeFuncs = require('../mime-funcs');
 const qp = require('../qp');
@@ -50,6 +51,37 @@ const PLAIN_ADDRESS = /^[^\s"(),:;<>@[\\\]]+@[^\s"(),:;<>@[\\\]]+$/;
  * @param {Function} [options.normalizeHeaderKey] method to normalize header keys for custom caseing
  * @param {String} [options.textEncoding] either 'Q' (the default) or 'B'
  */
+/**
+ * Encodes a domain the way browsers, the WHATWG URL Standard and DNS facing resolvers do,
+ * which is with UTS-46 mapping applied before the Punycode step.
+ *
+ * The bundled codec is plain RFC 3492 and maps nothing, so it disagrees with every
+ * conformant parser on any domain holding a mapped or ignored code point. An invisible
+ * U+00AD in 'compa\u00ADny.com' encoded to 'xn--company-pka.com' where a validator reads
+ * 'company.com', which let an allow-listed domain be checked and a different one mailed.
+ *
+ * Anything the URL parser does not accept as a hostname, an address literal such as
+ * '[127.0.0.1]' included, comes back empty and falls through to the bundled codec, which
+ * leaves those as they were supplied.
+ *
+ * @param {String} domain Domain to encode, already lowercased by the caller
+ * @param {Boolean} toUnicode Return the U-label form instead of the A-label form
+ * @return {String} Encoded domain
+ */
+function normalizeDomain(domain, toUnicode) {
+    // domainToASCII and domainToUnicode landed in Node 7, the bundled codec covers Node 6
+    const mapper = toUnicode ? urlModule.domainToUnicode : urlModule.domainToASCII;
+
+    if (typeof mapper === 'function') {
+        const mapped = mapper(domain);
+        if (mapped) {
+            return mapped;
+        }
+    }
+
+    return toUnicode ? punycode.toUnicode(domain) : punycode.toASCII(domain);
+}
+
 class MimeNode {
     constructor(contentType, options) {
         this.nodeCounter = 0;
@@ -1358,11 +1390,7 @@ class MimeNode {
         let encodedDomain = domain;
 
         try {
-            if (/[\x80-\uFFFF]/.test(user)) {
-                encodedDomain = punycode.toUnicode(domain.toLowerCase());
-            } else {
-                encodedDomain = punycode.toASCII(domain.toLowerCase());
-            }
+            encodedDomain = normalizeDomain(domain.toLowerCase(), /[\x80-\uFFFF]/.test(user));
         } catch (_err) {
             // keep domain as supplied
         }

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -904,9 +904,10 @@ class MimeNode {
                 this._envelope.from = list[0].address;
             }
         }
+        const seenRecipients = new Set();
         ['to', 'cc', 'bcc'].forEach(key => {
             if (envelope[key]) {
-                this._convertAddresses(this._parseEnvelopeAddresses(envelope[key]), this._envelope.to);
+                this._convertAddresses(this._parseEnvelopeAddresses(envelope[key]), this._envelope.to, seenRecipients);
             }
         });
 
@@ -925,15 +926,17 @@ class MimeNode {
      */
     getAddresses() {
         const addresses = {};
+        const seenByKey = new Map();
 
         this._headers.forEach(header => {
             const key = header.key.toLowerCase();
             if (['from', 'sender', 'reply-to', 'to', 'cc', 'bcc'].includes(key)) {
                 if (!Array.isArray(addresses[key])) {
                     addresses[key] = [];
+                    seenByKey.set(key, new Set());
                 }
 
-                this._convertAddresses(this._parseAddresses(header.value), addresses[key]);
+                this._convertAddresses(this._parseAddresses(header.value), addresses[key], seenByKey.get(key));
             }
         });
 
@@ -954,6 +957,12 @@ class MimeNode {
             from: false,
             to: []
         };
+
+        // Built once and carried across the headers. Letting _convertAddresses seed it per
+        // call would cost O(headers x recipients), and a message can carry many address
+        // headers: `headers: { to: [...] }` emits one To per entry.
+        const seenRecipients = new Set();
+
         this._headers.forEach(header => {
             const list = [];
             if (header.key === 'From' || (!envelope.from && ['Reply-To', 'Sender'].includes(header.key))) {
@@ -962,7 +971,7 @@ class MimeNode {
                     envelope.from = list[0].address;
                 }
             } else if (['To', 'Cc', 'Bcc'].includes(header.key)) {
-                this._convertAddresses(this._parseAddresses(header.value), envelope.to);
+                this._convertAddresses(this._parseAddresses(header.value), envelope.to, seenRecipients);
             }
         });
 

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -36,6 +36,14 @@ const QUOTED_STRING = /^"(?:[^"\\]|\\[\s\S])*"$/;
 // the envelope carries
 const PLAIN_ADDRESS = /^[^\s"(),:;<>@[\\\]]+@[^\s"(),:;<>@[\\\]]+$/;
 
+// domainToASCII and domainToUnicode are WHATWG host parsers rather than plain IDNA
+// mappers, so they do more than map: they cut the host at '/', '\\', '?' and '#', drop C0
+// controls, and percent-decode. Handing them 'evil.example/mail.corp.example' returns the
+// deliverable 'evil.example', which would turn a value the bundled codec leaves as
+// unroutable garbage into mail for a domain the sender never named. None of these
+// characters are legal in a domain, so keep them away from the mapper.
+const URL_PARSER_UNSAFE = /[/\\?#%\x00-\x20\x7F]/;
+
 /**
  * Encodes a domain the way browsers, the WHATWG URL Standard and DNS facing resolvers do,
  * which is with UTS-46 mapping applied before the Punycode step.
@@ -57,7 +65,7 @@ function normalizeDomain(domain, toUnicode) {
     // domainToASCII and domainToUnicode landed in Node 7, the bundled codec covers Node 6
     const mapper = toUnicode ? urlModule.domainToUnicode : urlModule.domainToASCII;
 
-    if (typeof mapper === 'function') {
+    if (typeof mapper === 'function' && !URL_PARSER_UNSAFE.test(domain)) {
         const mapped = mapper(domain);
         if (mapped) {
             return mapped;

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -37,21 +37,6 @@ const QUOTED_STRING = /^"(?:[^"\\]|\\[\s\S])*"$/;
 const PLAIN_ADDRESS = /^[^\s"(),:;<>@[\\\]]+@[^\s"(),:;<>@[\\\]]+$/;
 
 /**
- * Creates a new mime tree node. Assumes 'multipart/*' as the content type
- * if it is a branch, anything else counts as leaf. If rootNode is missing from
- * the options, assumes this is the root.
- *
- * @param {String} contentType Define the content type for the node. Can be left blank for attachments (derived from filename)
- * @param {Object} [options] optional options
- * @param {Object} [options.rootNode] root node for this tree
- * @param {Object} [options.parentNode] immediate parent for this node
- * @param {Object} [options.filename] filename for an attachment node
- * @param {String} [options.baseBoundary] shared part of the unique multipart boundary
- * @param {Boolean} [options.keepBcc] If true, do not exclude Bcc from the generated headers
- * @param {Function} [options.normalizeHeaderKey] method to normalize header keys for custom caseing
- * @param {String} [options.textEncoding] either 'Q' (the default) or 'B'
- */
-/**
  * Encodes a domain the way browsers, the WHATWG URL Standard and DNS facing resolvers do,
  * which is with UTS-46 mapping applied before the Punycode step.
  *
@@ -82,6 +67,21 @@ function normalizeDomain(domain, toUnicode) {
     return toUnicode ? punycode.toUnicode(domain) : punycode.toASCII(domain);
 }
 
+/**
+ * Creates a new mime tree node. Assumes 'multipart/*' as the content type
+ * if it is a branch, anything else counts as leaf. If rootNode is missing from
+ * the options, assumes this is the root.
+ *
+ * @param {String} contentType Define the content type for the node. Can be left blank for attachments (derived from filename)
+ * @param {Object} [options] optional options
+ * @param {Object} [options.rootNode] root node for this tree
+ * @param {Object} [options.parentNode] immediate parent for this node
+ * @param {Object} [options.filename] filename for an attachment node
+ * @param {String} [options.baseBoundary] shared part of the unique multipart boundary
+ * @param {Boolean} [options.keepBcc] If true, do not exclude Bcc from the generated headers
+ * @param {Function} [options.normalizeHeaderKey] method to normalize header keys for custom caseing
+ * @param {String} [options.textEncoding] either 'Q' (the default) or 'B'
+ */
 class MimeNode {
     constructor(contentType, options) {
         this.nodeCounter = 0;
@@ -1398,8 +1398,12 @@ class MimeNode {
 
         let encodedDomain = domain;
 
+        // A non-ASCII local part already requires SMTPUTF8, so the domain stays UTF-8 for
+        // symmetry on both sides of the '@' rather than being encoded to an A-label
+        const smtputf8 = /[\x80-\uFFFF]/.test(user);
+
         try {
-            encodedDomain = normalizeDomain(domain.toLowerCase(), /[\x80-\uFFFF]/.test(user));
+            encodedDomain = normalizeDomain(domain.toLowerCase(), smtputf8);
         } catch (_err) {
             // keep domain as supplied
         }

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -1057,28 +1057,38 @@ class MimeNode {
      * @return {Array} An array of address objects
      */
     _parseAddresses(addresses) {
-        return [].concat.apply(
-            [],
-            [].concat(addresses).map(address => {
-                if (address && address.address) {
-                    const normalized = this._normalizeAddress(address.address);
-                    if (normalized === address.address && typeof address.name === 'string') {
-                        // there is nothing to rewrite, so there is nothing to keep off the original
-                        return [address];
-                    }
+        // Collected into one list as we go. concat.apply spreads the entries into arguments
+        // and throws a RangeError once a recipient array is long enough to pass the
+        // argument limit, which a large Bcc list reaches on its own.
+        const flattened = [];
 
-                    // rewriting would land on the object the caller passed in and might
-                    // still hold a reference to, so rewrite a copy of it instead. An own
-                    // "__proto__" key would make the copy inherit from caller data, and
-                    // _convertAddresses reads `group` off it straight into the envelope
-                    const copy = shared.copyOwnKeys({}, address);
-                    copy.address = normalized;
-                    copy.name = address.name || '';
-                    return [copy];
+        [].concat(addresses).forEach(address => {
+            if (address && address.address) {
+                const normalized = this._normalizeAddress(address.address);
+                if (normalized === address.address && typeof address.name === 'string') {
+                    // there is nothing to rewrite, so there is nothing to keep off the original
+                    flattened.push(address);
+                    return;
                 }
-                return this._normalizeParsedAddresses(addressparser(address));
-            })
-        );
+
+                // rewriting would land on the object the caller passed in and might
+                // still hold a reference to, so rewrite a copy of it instead. An own
+                // "__proto__" key would make the copy inherit from caller data, and
+                // _convertAddresses reads `group` off it straight into the envelope
+                const copy = shared.copyOwnKeys({}, address);
+                copy.address = normalized;
+                copy.name = address.name || '';
+                flattened.push(copy);
+                return;
+            }
+
+            const parsed = this._normalizeParsedAddresses(addressparser(address));
+            for (let i = 0; i < parsed.length; i++) {
+                flattened.push(parsed[i]);
+            }
+        });
+
+        return flattened;
     }
 
     /**

--- a/lib/mime-node/index.js
+++ b/lib/mime-node/index.js
@@ -1267,10 +1267,21 @@ class MimeNode {
      * @param {Array} [uniqueList] An array to be populated with addresses
      * @return {String} address string
      */
-    _convertAddresses(addresses, uniqueList) {
+    _convertAddresses(addresses, uniqueList, seenAddresses) {
         const values = [];
 
         uniqueList = uniqueList || [];
+
+        // Membership is checked once per address, so scanning uniqueList itself would make
+        // a recipient list cost O(n^2). Groups recurse with the same set so that a nested
+        // group still dedupes against the addresses collected around it, and a caller that
+        // passes a partly filled list (To, then Cc, then Bcc) keeps deduping across headers.
+        if (!seenAddresses) {
+            seenAddresses = new Set();
+            for (let i = 0; i < uniqueList.length; i++) {
+                seenAddresses.add(uniqueList[i].address);
+            }
+        }
 
         [].concat(addresses || []).forEach(address => {
             if (address.address) {
@@ -1286,11 +1297,14 @@ class MimeNode {
                     values.push(`${this._encodeAddressName(address.name)} <${address.address}>`);
                 }
 
-                if (!uniqueList.some(a => a.address === address.address)) {
+                if (!seenAddresses.has(address.address)) {
+                    seenAddresses.add(address.address);
                     uniqueList.push(address);
                 }
             } else if (address.group) {
-                const groupListAddresses = (address.group.length ? this._convertAddresses(address.group, uniqueList) : '').trim();
+                const groupListAddresses = (
+                    address.group.length ? this._convertAddresses(address.group, uniqueList, seenAddresses) : ''
+                ).trim();
                 values.push(`${this._encodeAddressName(address.name)}:${groupListAddresses};`);
             }
         });

--- a/test/addressparser/addressparser-test.js
+++ b/test/addressparser/addressparser-test.js
@@ -1206,4 +1206,49 @@ describe('#addressparser', () => {
             ]);
         });
     });
+    describe('RFC 5322 comments', () => {
+        // A comment is folding whitespace, so it terminates the domain instead of joining
+        // the text around it. Gluing read 'user@good-corp.com(x)evil.com' as the domain
+        // 'good-corp.comevil.com', which an attacker can register, so an application that
+        // validated 'good-corp.com' mailed a domain it never approved.
+        it('should not glue a domain to the text after a comment', () => {
+            assert.deepStrictEqual(addressparser('user@good-corp.com(x)evil.com'), [{ address: 'user@good-corp.com', name: 'evil.com' }]);
+        });
+
+        it('should not glue across empty, repeated or nested comments', () => {
+            for (const input of [
+                'user@good-corp.com()evil.com',
+                'user@good-corp.com(a)(b)evil.com',
+                'user@good-corp.com(a)(b)(c)evil.com',
+                'user@good-corp.com(a(b)evil.com'
+            ]) {
+                assert.strictEqual(addressparser(input)[0].address, 'user@good-corp.com', input);
+            }
+        });
+
+        it('should keep both recipients when a comment splits an address list', () => {
+            const parsed = addressparser('a@b.com(c)d.com, e@f.com');
+            assert.strictEqual(parsed.length, 2);
+            assert.strictEqual(parsed[0].address, 'a@b.com');
+            assert.strictEqual(parsed[1].address, 'e@f.com');
+        });
+
+        // CFWS is allowed on either side of the '@', so a comment there still belongs to
+        // the same addr-spec and the address must survive intact.
+        it('should still resolve an address with a comment beside the @', () => {
+            assert.strictEqual(addressparser('user@(x)good-corp.com')[0].address, 'user@good-corp.com');
+            assert.strictEqual(addressparser('user(x)@good-corp.com')[0].address, 'user@good-corp.com');
+            assert.strictEqual(addressparser('(lead)user@good-corp.com')[0].address, 'user@good-corp.com');
+        });
+
+        it('should keep quoted string and angle address joining intact', () => {
+            assert.strictEqual(addressparser('"foo"bar@example.com')[0].address, 'foobar@example.com');
+            assert.strictEqual(addressparser('<a@b.com>x')[0].address, 'a@b.com');
+        });
+
+        it('should read a comment as the display name when there is none', () => {
+            assert.deepStrictEqual(addressparser('Foo (Bar) <foo@example.com>'), [{ address: 'foo@example.com', name: 'Foo' }]);
+            assert.deepStrictEqual(addressparser('(Bar) <foo@example.com>'), [{ address: 'foo@example.com', name: 'Bar' }]);
+        });
+    });
 });

--- a/test/addressparser/addressparser-test.js
+++ b/test/addressparser/addressparser-test.js
@@ -1148,4 +1148,62 @@ describe('#addressparser', () => {
             assert.ok(Array.isArray(result));
         });
     });
+    describe('linear time parsing', () => {
+        // A flat list used to be accumulated with parsedAddresses.concat(handled), which
+        // copied everything collected so far on every address. 200k recipients took ~25s
+        // of blocked event loop; the budget here is far above the linear cost (~100ms) and
+        // far below the quadratic one, so it only trips if the accumulator regresses.
+        it('should parse a large flat address list in linear time', () => {
+            const count = 200000;
+            const input = 'a@b.com,'.repeat(count);
+
+            const started = Date.now();
+            const result = addressparser(input);
+            const elapsed = Date.now() - started;
+
+            assert.strictEqual(result.length, count);
+            assert.ok(elapsed < 5000, `parsing ${count} addresses took ${elapsed}ms`);
+        });
+
+        // The display-name merge loop spliced each fragment out of the array, which is the
+        // same quadratic shape reached through a different input.
+        it('should merge display name fragments in linear time', () => {
+            const count = 80000;
+            const input = 'a, b <c@d.com>,'.repeat(count);
+
+            const started = Date.now();
+            const result = addressparser(input);
+            const elapsed = Date.now() - started;
+
+            assert.strictEqual(result.length, count);
+            assert.strictEqual(result[0].name, 'a, b');
+            assert.strictEqual(result[0].address, 'c@d.com');
+            assert.ok(elapsed < 5000, `merging ${count} fragments took ${elapsed}ms`);
+        });
+
+        it('should keep fragment merging identical to the previous implementation', () => {
+            assert.deepStrictEqual(addressparser('Joe Foo, PhD <joe@example.com>'), [{ address: 'joe@example.com', name: 'Joe Foo, PhD' }]);
+            assert.deepStrictEqual(addressparser('a, b, c <x@y.com>'), [{ address: 'x@y.com', name: 'a, b, c' }]);
+            assert.deepStrictEqual(addressparser('A <a@b.com>, B, C <c@d.com>'), [
+                { address: 'a@b.com', name: 'A' },
+                { address: 'c@d.com', name: 'B, C' }
+            ]);
+            assert.deepStrictEqual(addressparser('a@b.com, c@d.com'), [
+                { address: 'a@b.com', name: '' },
+                { address: 'c@d.com', name: '' }
+            ]);
+        });
+
+        it('should not merge fragments across a group boundary', () => {
+            assert.deepStrictEqual(addressparser('g: a@b.com, c@d.com;'), [
+                {
+                    name: 'g',
+                    group: [
+                        { address: 'a@b.com', name: '' },
+                        { address: 'c@d.com', name: '' }
+                    ]
+                }
+            ]);
+        });
+    });
 });

--- a/test/mailer/max-recipients-test.js
+++ b/test/mailer/max-recipients-test.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { SMTPServer } = require('smtp-server');
+const nodemailer = require('../../lib/nodemailer');
+
+const PORT_NUMBER = 8419;
+
+const uniqueRecipients = count => {
+    const list = new Array(count);
+    for (let i = 0; i < count; i++) {
+        list[i] = 'u' + i + '@example.com';
+    }
+    return list;
+};
+
+const message = (recipients, extra) =>
+    Object.assign(
+        {
+            from: 'sender@example.com',
+            to: recipients,
+            subject: 'test',
+            text: 'test'
+        },
+        extra || {}
+    );
+
+describe('maxRecipients', () => {
+    describe('jsonTransport', () => {
+        it('should reject a message over the transport limit', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+
+            await assert.rejects(
+                () => transport.sendMail(message(uniqueRecipients(11))),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+        });
+
+        it('should report the limit through a callback', (t, done) => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+
+            transport.sendMail(message(uniqueRecipients(11)), err => {
+                assert.ok(err, 'expected an error');
+                assert.strictEqual(err.code, 'EMAXRECIPIENTS');
+                done();
+            });
+        });
+
+        it('should accept a message on the limit', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+            const info = await transport.sendMail(message(uniqueRecipients(10)));
+
+            assert.strictEqual(info.envelope.to.length, 10);
+        });
+
+        it('should apply to a recipient array and a recipient string alike', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+
+            await assert.rejects(
+                () => transport.sendMail(message(uniqueRecipients(11))),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+            await assert.rejects(
+                () => transport.sendMail(message(uniqueRecipients(11).join(','))),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+        });
+
+        it('should count To, Cc and Bcc together, after deduplication', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 3 });
+
+            await assert.rejects(
+                () => transport.sendMail(message('a@example.com', { cc: 'b@example.com', bcc: ['c@example.com', 'd@example.com'] })),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+
+            const info = await transport.sendMail(message('a@example.com, a@example.com', { cc: 'b@example.com' }));
+            assert.deepStrictEqual(info.envelope.to, ['a@example.com', 'b@example.com']);
+        });
+
+        it('should honour a per message limit when the transport sets none', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true });
+
+            await assert.rejects(
+                () => transport.sendMail(message(uniqueRecipients(11), { maxRecipients: 10 })),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+        });
+
+        // The transport option is forced over message data, the same as disableFileAccess, so
+        // a message cannot raise a limit the transport owner set.
+        it('should not let a message raise the transport limit', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+
+            await assert.rejects(
+                () => transport.sendMail(message(uniqueRecipients(11), { maxRecipients: 1000 })),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+        });
+
+        // A caller supplied envelope goes straight to the transport, so it has to be counted
+        // too, otherwise the option is a bypass rather than a limit.
+        it('should apply to a caller supplied envelope', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 10 });
+
+            await assert.rejects(
+                () => transport.sendMail(message('a@example.com', { envelope: { from: 'sender@example.com', to: uniqueRecipients(11) } })),
+                err => err.code === 'EMAXRECIPIENTS'
+            );
+        });
+
+        it('should treat 0 as no limit', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true, maxRecipients: 0 });
+            const info = await transport.sendMail(message(uniqueRecipients(2000)));
+
+            assert.strictEqual(info.envelope.to.length, 2000);
+        });
+
+        it('should default to allowing an ordinary recipient list', async () => {
+            const transport = nodemailer.createTransport({ jsonTransport: true });
+            const info = await transport.sendMail(message(uniqueRecipients(500)));
+
+            assert.strictEqual(info.envelope.to.length, 500);
+        });
+    });
+
+    // The SMTP transports read the envelope inside an async continuation, well after send()
+    // has returned, so a limit enforced by throwing from there would leave sendMail with
+    // nothing to catch it and take the process down instead of reaching the caller.
+    describe('SMTP transports', () => {
+        let server;
+
+        before(
+            () =>
+                new Promise(resolve => {
+                    server = new SMTPServer({
+                        disabledCommands: ['STARTTLS', 'AUTH'],
+                        onData(stream, session, callback) {
+                            stream.on('data', () => {});
+                            stream.on('end', callback);
+                        }
+                    });
+                    server.listen(PORT_NUMBER, resolve);
+                })
+        );
+
+        after(() => new Promise(resolve => server.close(resolve)));
+
+        for (const pool of [false, true]) {
+            const label = pool ? 'pooled' : 'unpooled';
+
+            it(`should reject over the limit without crashing (${label})`, async () => {
+                const transport = nodemailer.createTransport({
+                    host: '127.0.0.1',
+                    port: PORT_NUMBER,
+                    secure: false,
+                    pool,
+                    maxRecipients: 2
+                });
+
+                await assert.rejects(
+                    () => transport.sendMail(message(['x@example.com', 'y@example.com', 'z@example.com'])),
+                    err => err.code === 'EMAXRECIPIENTS'
+                );
+                transport.close();
+            });
+
+            it(`should deliver a message under the limit (${label})`, async () => {
+                const transport = nodemailer.createTransport({
+                    host: '127.0.0.1',
+                    port: PORT_NUMBER,
+                    secure: false,
+                    pool,
+                    maxRecipients: 5
+                });
+                const info = await transport.sendMail(message(['x@example.com', 'y@example.com', 'z@example.com']));
+
+                assert.strictEqual(info.accepted.length, 3);
+                transport.close();
+            });
+        }
+    });
+});

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2342,4 +2342,20 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             assert.deepStrictEqual(mb.getEnvelope().to, ['a@example.com', 'b@example.com']);
         });
     });
+    describe('comment handling in recipients', () => {
+        it('should deliver to the domain before a comment, not the text after it', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('From', 'app@good-corp.com');
+            mb.setHeader('To', 'user@good-corp.com(x)evil.com');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['user@good-corp.com']);
+        });
+
+        it('should keep a comment beside the @ inside the same address', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'user@(x)good-corp.com');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['user@good-corp.com']);
+        });
+    });
 });

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2319,6 +2319,25 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             assert.strictEqual(mb.getEnvelope().to.length, count);
         });
 
+        // The dedupe set has to outlive one _convertAddresses call. Seeding it per call is
+        // O(headers x recipients), and header count is not bounded by three: `headers: { to:
+        // [...] }` emits one To header per entry, which made this shape slower than the
+        // linear-scan it replaced.
+        it('should stay linear when recipients are spread over many headers', () => {
+            const count = 20000;
+
+            const started = Date.now();
+            const mb = new MimeNode('text/plain');
+            for (let i = 0; i < count; i++) {
+                mb.addHeader('To', 'u' + i + '@example.com');
+            }
+            const envelope = mb.getEnvelope();
+            const elapsed = Date.now() - started;
+
+            assert.strictEqual(envelope.to.length, count);
+            assert.ok(elapsed < 2000, `${count} single-recipient headers took ${elapsed}ms`);
+        });
+
         it('should dedupe recipients across To, Cc and Bcc', () => {
             const mb = new MimeNode('text/plain');
             mb.setHeader('To', 'a@example.com, a@example.com, b@example.com');

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2436,6 +2436,32 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             assert.strictEqual(mb._normalizeAddress('user@ex_ample.com'), 'user@ex_ample.com');
         });
 
+        // domainToASCII and domainToUnicode are host parsers, not IDNA mappers: they cut the
+        // host at '/', '\\', '?' and '#' and percent-decode. Passing a domain through them
+        // unguarded turned 'attacker.example/mail.corp.example', which the bundled codec
+        // leaves unroutable, into deliverable mail for 'attacker.example', so an application
+        // allow-listing by suffix would approve one domain and send to another.
+        it('should not let a URL delimiter truncate the domain', () => {
+            const mb = new MimeNode('text/plain');
+
+            for (const domain of [
+                'attacker.example/mail.corp.example',
+                'attacker.example\\mail.corp.example',
+                'attacker.example?mail.corp.example',
+                'attacker.example#mail.corp.example',
+                'attacker.example%2email.corp.example'
+            ]) {
+                assert.strictEqual(mb._normalizeAddress('user@' + domain), 'user@' + domain, domain);
+            }
+        });
+
+        it('should keep a truncating domain out of the envelope', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'user@attacker.example/mail.corp.example');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['user@attacker.example/mail.corp.example']);
+        });
+
         it('should carry the mapped domain into the envelope', () => {
             const mb = new MimeNode('text/plain');
             mb.setHeader('To', 'victim@compa\u00ADny.com');

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2278,4 +2278,54 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             });
         });
     });
+    describe('recipient list scaling', () => {
+        const uniqueRecipients = count => {
+            const list = new Array(count);
+            for (let i = 0; i < count; i++) {
+                list[i] = 'u' + i + '@example.com';
+            }
+            return list;
+        };
+
+        // Recipients used to be deduped with uniqueList.some(), a linear scan per address,
+        // so a list of distinct recipients cost O(n^2). 100k took ~35s. The budget sits far
+        // above the linear cost (~100ms) and far below the quadratic one.
+        it('should build an envelope for a large unique recipient list in linear time', () => {
+            const count = 100000;
+            const recipients = uniqueRecipients(count);
+
+            const started = Date.now();
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', recipients.join(','));
+            const envelope = mb.getEnvelope();
+            const elapsed = Date.now() - started;
+
+            assert.strictEqual(envelope.to.length, count);
+            assert.ok(elapsed < 5000, `building ${count} recipients took ${elapsed}ms`);
+        });
+
+        it('should dedupe recipients across To, Cc and Bcc', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'a@example.com, a@example.com, b@example.com');
+            mb.setHeader('Cc', 'b@example.com, c@example.com');
+            mb.setHeader('Bcc', 'a@example.com, d@example.com');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['a@example.com', 'b@example.com', 'c@example.com', 'd@example.com']);
+        });
+
+        it('should dedupe a group against the addresses around it', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'x@example.com, grp: x@example.com, y@example.com;, y@example.com');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['x@example.com', 'y@example.com']);
+        });
+
+        it('should keep the rendered header list intact while deduping the envelope', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'A <a@example.com>, a@example.com, b@example.com');
+
+            assert.strictEqual(mb.getHeader('To'), 'A <a@example.com>, a@example.com, b@example.com');
+            assert.deepStrictEqual(mb.getEnvelope().to, ['a@example.com', 'b@example.com']);
+        });
+    });
 });

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2304,6 +2304,20 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             assert.ok(elapsed < 5000, `building ${count} recipients took ${elapsed}ms`);
         });
 
+        // _parseAddresses flattened with concat.apply, which spreads every parsed entry
+        // into arguments and threw "Maximum call stack size exceeded" from about 124k
+        // recipients upwards. A large Bcc list reaches that on its own, no crafted input.
+        it('should accept a recipient array past the argument limit', () => {
+            const count = 200000;
+            const recipients = uniqueRecipients(count);
+            const mb = new MimeNode('text/plain');
+
+            assert.doesNotThrow(() => {
+                mb.setHeader('To', recipients);
+            });
+            assert.strictEqual(mb.getEnvelope().to.length, count);
+        });
+
         it('should dedupe recipients across To, Cc and Bcc', () => {
             const mb = new MimeNode('text/plain');
             mb.setHeader('To', 'a@example.com, a@example.com, b@example.com');

--- a/test/mime-node/mime-node-test.js
+++ b/test/mime-node/mime-node-test.js
@@ -2,6 +2,7 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
+const urlModule = require('url');
 const MimeNode = require('../../lib/mime-node');
 const addressparser = require('../../lib/addressparser');
 const http = require('http');
@@ -2356,6 +2357,71 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             mb.setHeader('To', 'user@(x)good-corp.com');
 
             assert.deepStrictEqual(mb.getEnvelope().to, ['user@good-corp.com']);
+        });
+    });
+    describe('UTS-46 domain encoding', () => {
+        // The bundled Punycode codec maps nothing, so an ignored or mapped code point
+        // encoded to a different A-label than every conformant parser. An application that
+        // allow-listed 'company.com' with url.domainToASCII approved the recipient while
+        // Nodemailer delivered to 'xn--company-pka.com'.
+        it('should fold away an ignored code point like a validator does', () => {
+            const mb = new MimeNode('text/plain');
+
+            assert.strictEqual(mb._normalizeAddress('victim@compa\u00ADny.com'), 'victim@company.com');
+        });
+
+        it('should map full width characters to their canonical form', () => {
+            const mb = new MimeNode('text/plain');
+
+            assert.strictEqual(mb._normalizeAddress('victim@\uFF43\uFF4F\uFF4D\uFF50\uFF41\uFF4E\uFF59.com'), 'victim@company.com');
+        });
+
+        it('should agree with url.domainToASCII on every encodable domain', () => {
+            const mb = new MimeNode('text/plain');
+            const domains = [
+                'compa\u00ADny.com',
+                'exa\u0301mple.com',
+                'jõgeva.ee',
+                'münchen.de',
+                'пример.рф',
+                '日本.jp',
+                'xn--jgeva-dua.ee',
+                'EXAMPLE.COM',
+                'example.com'
+            ];
+
+            for (const domain of domains) {
+                const reference = urlModule.domainToASCII(domain.toLowerCase());
+                const encoded = mb
+                    ._normalizeAddress('user@' + domain)
+                    .split('@')
+                    .pop();
+                assert.strictEqual(encoded, reference, domain);
+            }
+        });
+
+        it('should map the domain for an SMTPUTF8 address too', () => {
+            const mb = new MimeNode('text/plain');
+
+            assert.strictEqual(mb._normalizeAddress('käsu@compa\u00ADny.com'), 'käsu@company.com');
+            assert.strictEqual(mb._normalizeAddress('käsu@jõgeva.ee'), 'käsu@jõgeva.ee');
+        });
+
+        // domainToASCII returns an empty string for anything that is not a hostname, so
+        // these have to fall through to the bundled codec and stay as supplied.
+        it('should leave address literals and non hostnames alone', () => {
+            const mb = new MimeNode('text/plain');
+
+            assert.strictEqual(mb._normalizeAddress('user@[127.0.0.1]'), 'user@[127.0.0.1]');
+            assert.strictEqual(mb._normalizeAddress('user@[IPv6:::1]'), 'user@[ipv6:::1]');
+            assert.strictEqual(mb._normalizeAddress('user@ex_ample.com'), 'user@ex_ample.com');
+        });
+
+        it('should carry the mapped domain into the envelope', () => {
+            const mb = new MimeNode('text/plain');
+            mb.setHeader('To', 'victim@compa\u00ADny.com');
+
+            assert.deepStrictEqual(mb.getEnvelope().to, ['victim@company.com']);
         });
     });
 });


### PR DESCRIPTION
Addresses the three open draft advisories, plus three further defects found while verifying them. Every fix has tests that were confirmed to fail without it.

### Advisory fixes

- **GHSA-2x7j-588g-ccc2** (quadratic parsing). Two accumulators in `addressparser` were O(n²): the `concat` accumulator and the display-name merge `splice` loop. 200k addresses drop from ~25s of blocked event loop to ~80ms.
- **GHSA-cc9r-2j5m-2m83** (RFC 5322 comment glue). `user@good-corp.com(x)evil.com` parsed as the single registrable domain `good-corp.comevil.com`. A comment is folding whitespace, so it now terminates the domain, while a comment beside the `@` still resolves.
- **GHSA-wmmp-3585-3rmp** (IDN/UTS-46). The bundled RFC 3492 codec maps nothing, so an invisible U+00AD encoded to `xn--company-pka.com` where every conformant validator reads `company.com`. Domain encoding now runs UTS-46.

### Found while verifying

- **The reported PoC hid the worst path.** It repeated one address, which deduped to a single entry. `_convertAddresses` deduped with a linear scan per address, so a list of *distinct* recipients was O(n²): 100k unique took ~35s even after fixing `addressparser`.
- **`[].concat.apply` threw `RangeError: Maximum call stack size exceeded`** past ~124k recipients. A large Bcc array hit this with no attacker involved.
- **`url.domainToASCII` is a WHATWG host parser, not an IDNA mapper.** It cuts the host at `/`, `\`, `?`, `#` and percent-decodes, so the UTS-46 fix above initially turned `user@attacker.example/mail.corp.example` into deliverable mail for `attacker.example`. Guarded, and swept every code point to U+2FFFF to confirm no label is dropped and no CR/LF or second `@` is reachable.

### New option

`maxRecipients` caps recipients per message. It throws rather than truncating, counts the deduped envelope across To/Cc/Bcc and a caller-supplied envelope, and is configurable on `createTransport` (forced, like `disableFileAccess`) or per message. `0` lifts it. Default 100000, a backstop rather than a delivery policy.

It is enforced in `Mail#sendMail` before a connection opens, **not** in `getEnvelope()`: the SMTP transports read the envelope inside an async continuation, so throwing from there escaped every caller and crashed the process. Tests run against a live `smtp-server`, pooled and unpooled, since a suite built only on `jsonTransport` did not catch that.

### Verification

| | before | after |
|---|---|---|
| addressparser 100k | 3,321 ms | 44 ms |
| envelope 40k unique | 2,384 ms | 43 ms |
| 20k recipients / 20k headers | 388 ms | 29 ms |
| array past 124k | `RangeError` | linear to 400k |

All three advisory PoCs run clean verbatim. 769 tests pass, lint clean, Node 6 syntax check passes.

Reported by @e1abrador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L24TKDLTJZqRXKrfZi3736
