### PR TITLE
fix: resolve well-known services by their primary domains

### DIFF
--- a/src/well-known/services.json
+++ b/src/well-known/services.json
@@ -107,7 +107,7 @@
 
     "FastMail": {
         "description": "FastMail",
-        "domains": ["fastmail.fm"],
+        "domains": ["fastmail.com", "fastmail.fm"],
         "host": "smtp.fastmail.com",
         "port": 465,
         "secure": true
@@ -196,7 +196,7 @@
     "iCloud": {
         "description": "iCloud Mail",
         "aliases": ["Me", "Mac"],
-        "domains": ["me.com", "mac.com"],
+        "domains": ["icloud.com", "me.com", "mac.com"],
         "host": "smtp.mail.me.com",
         "port": 587
     },

--- a/test/well-known/well-known-test.ts
+++ b/test/well-known/well-known-test.ts
@@ -31,6 +31,23 @@ describe('Well-Known Services Tests', () => {
             });
         });
 
+        it('Should find iCloud by its primary domain', () => {
+            assert.deepStrictEqual(wellKnown('test@icloud.com'), {
+                description: 'iCloud Mail',
+                host: 'smtp.mail.me.com',
+                port: 587
+            });
+        });
+
+        it('Should find FastMail by its primary domain', () => {
+            assert.deepStrictEqual(wellKnown('test@fastmail.com'), {
+                description: 'FastMail',
+                host: 'smtp.fastmail.com',
+                port: 465,
+                secure: true
+            });
+        });
+
         it('Should find no match', () => {
             assert.strictEqual(wellKnown('zzzzzz'), false);
         });


### PR DESCRIPTION
NB! Nodemailer is frozen, so no new features please, only bug fixes.

Fixes #1858.

wellKnown('test@icloud.com') and wellKnown('test@fastmail.com') returned false because icloud.com and fastmail.com were missing from the domains lists, so service-based setup silently got no SMTP settings for those addresses. Adds the two domains; no behavior change otherwise.

Tests: added lookup cases to test/well-known/well-known-test.ts (6/6 pass), neighboring smtp-transport suite 14/14 pass, npm run lint and format:check clean.