### PR TITLE
Send cookies set with Path back to the exact path

### DIFF
--- a/src/fetch/cookies.ts
+++ b/src/fetch/cookies.ts
@@ -213,9 +213,14 @@ export default class Cookies {
             return false;
         }
 
-        // check if path matches
-        const path = this.getPath(urlparts.pathname);
-        if (path.substr(0, (cookie.path as string).length) !== cookie.path) {
+        // check if the request path path-matches the cookie path (RFC 6265 section 5.1.4):
+        // identical paths match, otherwise the cookie path must be a directory prefix
+        const pathname = urlparts.pathname || '/';
+        const cookiePath = cookie.path as string;
+        if (
+            pathname !== cookiePath &&
+            !(pathname.startsWith(cookiePath) && (cookiePath.endsWith('/') || pathname.charAt(cookiePath.length) === '/'))
+        ) {
             return false;
         }
 

--- a/test/fetch/cookies-test.ts
+++ b/test/fetch/cookies-test.ts
@@ -291,6 +291,22 @@ describe('Cookie Tests', () => {
             assert.strictEqual(biskviit.match(cookie, 'https://example.com/def/'), true);
             assert.strictEqual(biskviit.match(cookie, 'http://example.com/def/'), false);
         });
+
+        it('should match a cookie on the exact request path (RFC 6265 section 5.1.4)', () => {
+            let cookie = {
+                name: 'zzz',
+                value: 'abc',
+                path: '/def',
+                expires: new Date(Date.now() + 10000),
+                domain: 'example.com',
+                secure: false,
+                httponly: false
+            };
+            assert.strictEqual(biskviit.match(cookie, 'http://example.com/def'), true);
+            assert.strictEqual(biskviit.match(cookie, 'http://example.com/def/'), true);
+            assert.strictEqual(biskviit.match(cookie, 'http://example.com/def/ghi'), true);
+            assert.strictEqual(biskviit.match(cookie, 'http://example.com/defghi'), false);
+        });
     });
 
     describe('#parse', () => {


### PR DESCRIPTION
A cookie stored with an explicit Path was never sent back to that exact URL, only to paths below it:

```js
jar.set('sess=abc; Path=/login', 'http://example.com/login');
jar.get('http://example.com/login'); // '' before, 'sess=abc' after
```

match() only compared the directory part of the request path, so identical request and cookie paths never matched. That misses the first rule of RFC 6265 section 5.1.4. The check now compares the full request path: identical paths match, otherwise the cookie path must be a directory prefix (sibling paths like /login2 still do not match).

Verified with the cookie and fetch suites (69 tests green) plus the full suite (1276 green) and lint.