### PR TITLE
Throw a configuration error when the SES client is missing

### DIFF
--- a/src/ses-transport/index.ts
+++ b/src/ses-transport/index.ts
@@ -76,6 +76,14 @@ class SESTransport extends EventEmitter {
         super();
         options = options || ({} as SESTransportOptions);
 
+        if (!options.SES || !options.SES.sesClient) {
+            const error: NodemailerError = new Error(
+                'Missing SES configuration, expecting { sesClient, SendEmailCommand } from @aws-sdk/client-sesv2, see https://nodemailer.com/transports/ses/'
+            );
+            error.code = errors.ECONFIG;
+            throw error;
+        }
+
         this.options = options;
         this.ses = this.options.SES;
 

--- a/test/ses-transport/ses-transport-test.ts
+++ b/test/ses-transport/ses-transport-test.ts
@@ -258,6 +258,20 @@ describe('SES Transport Tests', { timeout: 90 * 1000 }, () => {
         );
     });
 
+    it('should throw ECONFIG when the SES client is missing', () => {
+        // without a client, send() dies with an uncaught TypeError inside setImmediate
+        // and verify() throws a TypeError instead of failing the callback or promise.
+        // (SES: undefined stays an SMTP transport, like any other falsy transport flag.)
+        assert.throws(
+            () => nodemailer.createTransport({ SES: {} } as any),
+            (err: any) => err.code === 'ECONFIG' && /sesClient/.test(err.message)
+        );
+        assert.throws(
+            () => nodemailer.createTransport({ SES: { SendEmailCommand: class {} } } as any),
+            (err: any) => err.code === 'ECONFIG' && /sesClient/.test(err.message)
+        );
+    });
+
     it('should surface a synchronous SendEmailCommand failure as a single error callback', (t, done) => {
         let transport = nodemailer.createTransport({
             SES: {


### PR DESCRIPTION
Creating an SES transport without sesClient did not fail at setup. It crashed later instead: sendMail() died with an uncaught TypeError inside setImmediate so the send callback never ran, and verify() threw a TypeError instead of failing the callback or rejecting the returned promise.

This change throws an ECONFIG error from the constructor when options.SES has no sesClient, so the misconfiguration surfaces at createTransport time. Cases where SendEmailCommand is missing but the client exists already fail gracefully through the send callback, so those are left alone.