### PR TITLE
fix(mime-funcs): do not double encode Buffer input when chunking base64 mime words

### DIFF
--- a/src/mime-funcs/index.ts
+++ b/src/mime-funcs/index.ts
@@ -113,7 +113,10 @@ export function encodeWord(data: string | Buffer, mimeWordEncoding?: string, max
             return '=' + (ord.length === 1 ? '0' + ord : ord);
         });
     } else if (mimeWordEncoding === 'B') {
-        encodedStr = typeof data === 'string' ? data : base64.encode(data);
+        // the chunking loop below splits raw text and base64 encodes each part, so a
+        // Buffer goes in as its UTF-8 string: handing it the base64 of the whole input
+        // would encode the encoding itself and decode back to base64 text
+        encodedStr = typeof data === 'string' ? data : data.toString('utf-8');
         maxLength = maxLength ? Math.max(3, ((maxLength - (maxLength % 4)) / 4) * 3) : 0;
     }
 

--- a/test/mime-funcs/mime-funcs-test.ts
+++ b/test/mime-funcs/mime-funcs-test.ts
@@ -161,6 +161,15 @@ describe('Mime-Funcs Tests', { timeout: 50 * 1000 }, () => {
 
             assert.strictEqual('�' + '\u{20000}'.repeat(4), libmime.decodeWords(encoded));
         });
+
+        it('should not double encode a Buffer when chunking base64', () => {
+            // a Buffer used to go into the chunking loop as the base64 of the whole
+            // input, so every part was encoded twice and decoded back to base64 text
+            const inputStr = 'Hello wörld, this is a longer filename with ünicode.txt',
+                encoded = mimeFuncs.encodeWord(Buffer.from(inputStr), 'B', 30);
+
+            assert.strictEqual(inputStr, libmime.decodeWords(encoded));
+        });
     });
 
     describe('#buildHeaderParam', () => {


### PR DESCRIPTION
encodeWord with a Buffer and the B encoding fed base64 of the whole input into the chunking loop, which base64 encodes every part again. The words decoded back to base64 text instead of the original value.

Before: encodeWord(Buffer.from('Hello wörld, ...'), 'B', 30) produced words whose payloads decode to 'SGVsbG8gd8O2' etc. After: they decode back to the input (pinned by a roundtrip test through libmime.decodeWords).