### PR TITLE
fix(smtp-pool): release rate-limited connections on close

### DIFF
--- a/src/smtp-pool/index.ts
+++ b/src/smtp-pool/index.ts
@@ -219,8 +219,10 @@ class SMTPPool extends EventEmitter {
         const len = this._connections.length;
         this._closed = true;
 
-        // clear rate limit timer if it exists
-        clearTimeout(this._rateLimit.timeout as NodeJS.Timeout);
+        // release connections gated by the rate limiter so they become
+        // available and are torn down below instead of leaking with a
+        // cleared timer that never fires
+        this._clearRateLimit();
 
         if (!len && !this._queue.length) {
             return;

--- a/test/smtp-pool/smtp-pool-lifecycle-test.ts
+++ b/test/smtp-pool/smtp-pool-lifecycle-test.ts
@@ -176,6 +176,45 @@ describe('SMTP pool lifecycle', { timeout: 20000 }, () => {
                 await ts.close();
             }
         });
+
+        it('close() tears down connections gated by the rate limiter', async () => {
+            const ts = await startServer();
+            const pool = new SMTPPool({
+                host: '127.0.0.1',
+                port: ts.port,
+                maxConnections: 1,
+                rateLimit: 1,
+                rateDelta: 60000,
+                auth,
+                logger: false
+            });
+
+            try {
+                const first = await settle(pool, mockMail(envelope));
+                assert.ifError(first.err);
+                // let the post-send release gate the connection on the rate limiter
+                await new Promise(resolve => setTimeout(resolve, 50));
+                assert.strictEqual(pool._rateLimit.waiting.length, 1);
+
+                const gated = pool._connections[0];
+                const queued = settle(pool, mockMail(envelope));
+                pool.close();
+
+                const { err } = await queued;
+                assert.ok(err);
+                assert.strictEqual(err.message, 'Connection pool was closed');
+
+                // the gated connection is released and torn down, not leaked
+                await new Promise(resolve => setTimeout(resolve, 50));
+                assert.strictEqual(pool._rateLimit.waiting.length, 0);
+                assert.strictEqual(pool._rateLimit.timeout, null);
+                assert.strictEqual(gated.connection.destroyed, true);
+                assert.strictEqual(pool._connections.length, 0);
+            } finally {
+                pool.close();
+                await ts.close();
+            }
+        });
     });
 
     describe('connection failures', () => {


### PR DESCRIPTION
close() cleared the rate limit timer without releasing the gated connections. A connection waiting out its rateDelta window stayed in the pool with an open socket after close().

Flushing the limiter instead lets those connections become available, and the available handler tears them down because the pool is closed. Queued messages are still failed with 'Connection pool was closed' as before.

Includes a regression test that sends one message under rateLimit: 1, closes the pool with a second message queued, and asserts the queued message fails while the gated connection is torn down.