### PR TITLE
fix(mime-node): strip line breaks from multipart boundary material

### DIFF
--- a/src/mime-node/index.ts
+++ b/src/mime-node/index.ts
@@ -310,10 +310,12 @@ class MimeNode {
         options = options || {};
 
         /**
-         * shared part of the unique multipart boundary
+         * shared part of the unique multipart boundary. A line break here would split
+         * the delimiter lines the tree is streamed with, so the declared boundary could
+         * never match them again and the remainder would go out as body lines
          */
-        this.baseBoundary = options.baseBoundary || crypto.randomBytes(8).toString('hex');
-        this.boundaryPrefix = options.boundaryPrefix || '--_NmP';
+        this.baseBoundary = (options.baseBoundary || crypto.randomBytes(8).toString('hex')).replace(/\r|\n/g, '');
+        this.boundaryPrefix = (options.boundaryPrefix || '--_NmP').replace(/\r|\n/g, '');
 
         this.disableFileAccess = !!options.disableFileAccess;
         this.disableUrlAccess = !!options.disableUrlAccess;
@@ -1499,8 +1501,15 @@ class MimeNode {
         this.multipart = /^multipart\//i.test(this.contentType) ? this.contentType.substr(this.contentType.indexOf('/') + 1) : false;
 
         if (this.multipart) {
-            this.boundary = (structured.params as Record<string, string>).boundary =
-                (structured.params as Record<string, string>).boundary || this.boundary || this._generateBoundary();
+            // A line break in the boundary would split the delimiter lines the tree is
+            // streamed with, so the declared boundary could never match them again and
+            // the remainder would go out as body lines. Anything else is kept as is, it
+            // stays on one line and matches literally on both sides.
+            this.boundary = (structured.params as Record<string, string>).boundary = (
+                (structured.params as Record<string, string>).boundary ||
+                this.boundary ||
+                this._generateBoundary()
+            ).replace(/\r|\n/g, '');
         } else {
             this.boundary = false;
         }

--- a/test/mime-node/mime-node-test.ts
+++ b/test/mime-node/mime-node-test.ts
@@ -486,6 +486,44 @@ describe('MimeNode Tests', { timeout: 50 * 1000 }, () => {
             });
         });
 
+        it('should strip line breaks from custom boundary material', (t, done) => {
+            // a line break in the boundary would split the delimiter lines, so the
+            // declared boundary could never match them again
+            let mb = new MimeNode('multipart/mixed', {
+                baseBoundary: 'te\r\nst',
+                boundaryPrefix: '--P\r\nX'
+            });
+
+            mb.createChild('text/plain').setContent('Hello world!');
+
+            mb.build((err, msg: any) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                assert.ok(!/[\r\n]/.test(mb.boundary as string), 'boundary must not hold a line break');
+                assert.strictEqual(mb.boundary, '--PX-test-Part_1');
+                assert.ok(msg.includes('boundary="--PX-test-Part_1"'));
+                assert.ok(msg.includes('\r\n----PX-test-Part_1\r\n'));
+                assert.ok(msg.includes('\r\n----PX-test-Part_1--\r\n'));
+                done();
+            });
+        });
+
+        it('should strip line breaks from an explicit boundary parameter', (t, done) => {
+            let mb = new MimeNode('multipart/mixed');
+            mb.setHeader('Content-Type', 'multipart/mixed; boundary="AA\r\nBB"');
+            mb.createChild('text/plain').setContent('Hello world!');
+
+            mb.build((err, msg: any) => {
+                assert.ok(!err);
+                msg = msg.toString();
+                assert.strictEqual(mb.boundary, 'AABB');
+                assert.ok(/^Content-Type: multipart\/mixed; boundary=(?:"AABB"|AABB)$/m.test(msg));
+                assert.ok(msg.includes('\r\n--AABB\r\n'));
+                assert.ok(msg.includes('\r\n--AABB--\r\n'));
+                done();
+            });
+        });
+
         it('should not emit a blank line before the boundary when base64 body length is an exact multiple of lineLength (regression #1810)', (t, done) => {
             let mb = new MimeNode('multipart/mixed');
             // 114 bytes -> 152 base64 chars = 2 * 76. Before the fix, the


### PR DESCRIPTION
A CR or LF in baseBoundary, boundaryPrefix, or an explicit boundary parameter split the MIME delimiter lines while the declared boundary went out RFC2231-encoded, so the two sides never matched and receivers got an unparseable multipart body. The fix drops CR/LF where the boundary is assigned (constructor and _handleContentType), keeping declared and streamed boundaries identical.

Tests: two new build-level cases in test/mime-node/mime-node-test.ts (fail before, pass after). mime-node (181), mail-composer (62), and mailer (67) suites green, lint and typecheck green.